### PR TITLE
refactor(ci): ai-review via github apps (no api keys)

### DIFF
--- a/.github/AI_REVIEW_RUBRIC.md
+++ b/.github/AI_REVIEW_RUBRIC.md
@@ -1,3 +1,5 @@
+<!-- tested with: claude code v2.1.118 -->
+
 # ai review rubric
 
 canonical review contract for the ai-review-team workflow. every reviewer (claude, codex, future ones) reads this before posting a review. the rubric is what makes dual-reviewer output consistent instead of two different bots shouting past each other.
@@ -94,8 +96,28 @@ the reviewer does not post these. count them in the dismissed summary only.
 
 overlap is fine when both reviewers spot the same issue; the rubric's `apply` / `blocking` dedup is by `path:line`.
 
+## issue triage
+
+when mentioned on a new issue, post a single comment in this exact shape:
+
+```
+## triage
+
+- category: bug | feature | docs | question | other
+- priority: p0 | p1 | p2 | p3
+- summary: one paragraph, no filler
+
+## next steps
+
+- [ ] concrete first action (who does what)
+- [ ] concrete second action
+- [ ] concrete third action (optional)
+```
+
+voice rules from the top of this file still apply. no em dashes, no marketing adjectives, lowercase trademarks. priority guidance: p0 = broken main path, p1 = blocks a user this week, p2 = nice to have, p3 = someday.
+
 ## frequency + trigger
 
-- opened, synchronize, reopened, ready_for_review on pull_request.
+- opened, ready_for_review on pull_request (draft prs skipped).
 - opened on issues (claude only; codex focuses on code).
 - manual trigger via `workflow_dispatch` for re-review.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,12 +1,14 @@
 name: AI Review Team
 
-# replaces coderabbit. two reviewers post separately; both read the
-# canonical rubric at .github/AI_REVIEW_RUBRIC.md so output is consistent.
+# both reviewers ride on github apps tied to the user's subscriptions
+# (claude max + chatgpt plus). this workflow posts one @mention comment per
+# pr/issue pointing both apps at the canonical rubric; the apps respond.
+# no api keys, no per-token billing, no curl plumbing.
 # see docs/review-process.md for the full process.
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, ready_for_review]
   issues:
     types: [opened]
   workflow_dispatch:
@@ -26,210 +28,52 @@ permissions:
   issues: write
 
 jobs:
-  claude-review:
-    name: claude
+  pr-review:
+    name: mention reviewers
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft != true
-    continue-on-error: true  # non-blocking; fails quietly if ANTHROPIC_API_KEY is unset
+    if: github.event_name != 'issues' && github.event.pull_request.draft != true
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
-      - name: skip if no api key
+      - name: check for recent mention
         id: guard
         env:
-          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
-          if [ "${HAS_KEY}" != "true" ]; then
-            echo "ANTHROPIC_API_KEY unset; skipping claude review. set it in repo settings -> secrets to enable."
+          set -euo pipefail
+          cutoff=$(python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc) - timedelta(days=7)).isoformat())")
+          recent=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"@claude\")) and .created_at > \"${cutoff}\")] | length")
+          if [ "${recent}" -gt 0 ]; then
+            echo "found ${recent} recent @claude mention(s) from this workflow within 7 days; skipping to avoid re-mention loop"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: read rubric
-        if: steps.guard.outputs.skip != 'true'
-        id: rubric
-        run: |
-          {
-            echo 'content<<RUBRIC_EOF'
-            cat .github/AI_REVIEW_RUBRIC.md
-            echo 'RUBRIC_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: run claude review
+      - name: post review mention
         if: steps.guard.outputs.skip != 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-          RUBRIC: ${{ steps.rubric.outputs.content }}
-        run: |
-          set -euo pipefail
-
-          diff_body=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff')
-
-          # cap diff at ~200k chars to stay well under claude's input ceiling
-          if [ ${#diff_body} -gt 200000 ]; then
-            diff_body="${diff_body:0:200000}"$'\n\n[diff truncated at 200k chars]'
-          fi
-
-          payload=$(jq -n \
-            --arg sys "you are the claude reviewer on the ai-review-team. read the rubric below and follow it exactly. your lane: prose, voice, api/contract shape, skill + hook + plugin surface correctness, tests for the public path. skip perf micro-nits. produce one pr review comment in the exact output format from the rubric. set reviewer: claude. commit reviewed: ${COMMIT_SHA}." \
-            --arg rubric "$RUBRIC" \
-            --arg diff "$diff_body" \
-            '{
-              model: "claude-opus-4-7",
-              max_tokens: 4096,
-              system: ($sys + "\n\nRUBRIC:\n" + $rubric),
-              messages: [ { role: "user", content: ("diff to review:\n\n" + $diff) } ]
-            }')
-
-          review_body=$(curl -sS https://api.anthropic.com/v1/messages \
-            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -d "$payload" \
-            | jq -r '.content[0].text // empty')
-
-          if [ -z "$review_body" ]; then
-            echo "claude returned empty review; skipping post"
-            exit 0
-          fi
-
-          gh pr comment "$PR_NUMBER" --body "$review_body"
-
-  codex-review:
-    name: codex
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft != true
-    continue-on-error: true  # non-blocking; fails quietly if OPENAI_API_KEY is unset
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: skip if no api key
-        id: guard
-        env:
-          HAS_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
-        run: |
-          if [ "${HAS_KEY}" != "true" ]; then
-            echo "OPENAI_API_KEY unset; skipping codex review. set it in repo settings -> secrets to enable."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: read rubric
-        if: steps.guard.outputs.skip != 'true'
-        id: rubric
-        run: |
-          {
-            echo 'content<<RUBRIC_EOF'
-            cat .github/AI_REVIEW_RUBRIC.md
-            echo 'RUBRIC_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: run codex review
-        if: steps.guard.outputs.skip != 'true'
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -euo pipefail
-
-          # fetch the pr diff
-          diff_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -H 'Accept: application/vnd.github.v3.diff')
-
-          # call openai responses api with the rubric + diff
-          # model choice: o3-mini for cost/latency; swap to o3 or gpt-4.1 for deeper passes
-          payload=$(jq -n \
-            --arg rubric "${{ steps.rubric.outputs.content }}" \
-            --arg diff "$diff_json" \
-            --arg sha "${{ github.event.pull_request.head.sha }}" \
-            '{
-              model: "o3-mini",
-              reasoning: { effort: "medium" },
-              input: [
-                {
-                  role: "system",
-                  content: "you are the codex reviewer on the ai-review-team. read the rubric below and follow it exactly. your lane: bugs, security, type/shell correctness, dependency hygiene, ci config. skip voice + marketing adjective nits (claude handles those). produce one pr review comment in the exact output format from the rubric. set reviewer: codex. commit reviewed: \($sha).\n\nRUBRIC:\n\($rubric)"
-                },
-                {
-                  role: "user",
-                  content: "diff to review:\n\n\($diff)"
-                }
-              ]
-            }')
-
-          review_body=$(curl -sS https://api.openai.com/v1/responses \
-            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            | jq -r '.output[0].content[0].text // .output_text // empty')
-
-          if [ -z "$review_body" ]; then
-            echo "codex returned empty review; skipping post"
-            exit 0
-          fi
-
-          gh pr comment "$PR_NUMBER" --body "$review_body"
+          body=$'@claude @codex please review this pr per [.github/AI_REVIEW_RUBRIC.md](.github/AI_REVIEW_RUBRIC.md).\n\nlanes:\n- claude: prose, voice, api/contract shape, skill + hook + plugin surface correctness, tests for the public path.\n- codex: bugs, security, type/shell correctness, dependency hygiene, ci config.\n\noutput one pr comment each in the exact shape from the rubric. if an app is not installed on this repo, the mention sits unanswered and ci stays green.'
+          gh pr comment "${PR_NUMBER}" --body "${body}"
 
   issue-triage:
-    name: claude-issue-triage
+    name: mention triage
     runs-on: ubuntu-latest
     if: github.event_name == 'issues'
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
-      - name: skip if no api key
-        id: guard
+      - name: post triage mention
         env:
-          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
-        run: |
-          if [ "${HAS_KEY}" != "true" ]; then
-            echo "ANTHROPIC_API_KEY unset; skipping issue triage."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: run claude issue triage
-        if: steps.guard.outputs.skip != 'true'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-
-          issue=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}")
-          title=$(echo "$issue" | jq -r '.title')
-          body=$(echo "$issue" | jq -r '.body // ""')
-
-          payload=$(jq -n \
-            --arg sys "triage this github issue. output a single comment with: category (bug | feature | docs | question | other), suggested priority (p0 | p1 | p2 | p3), one-paragraph summary, two to four suggested next steps. voice: lowercase, no em dashes, no marketing adjectives." \
-            --arg title "$title" \
-            --arg body "$body" \
-            '{
-              model: "claude-haiku-4-5-20251001",
-              max_tokens: 1024,
-              system: $sys,
-              messages: [ { role: "user", content: ("title: " + $title + "\n\nbody:\n" + $body) } ]
-            }')
-
-          triage=$(curl -sS https://api.anthropic.com/v1/messages \
-            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -d "$payload" \
-            | jq -r '.content[0].text // empty')
-
-          if [ -n "$triage" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "$triage"
-          fi
+          body='@claude please triage this issue per [.github/AI_REVIEW_RUBRIC.md](.github/AI_REVIEW_RUBRIC.md) (issue-triage section).'
+          gh issue comment "${ISSUE_NUMBER}" --body "${body}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ data/*
 !data/stats.json
 handoffs/
 AUDIT.md
-AGENTS.md
 .phase-a-audit.md
 docs/upstream-watcher-design.md
 .claude/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+<!-- tested with: claude code v2.1.118 -->
+
+# claude-code-tips (codex / openai agents pointer)
+
+personal claude code setup, open source. hooks, example agents/commands, opinionated docs. marketplace name: `cc` (install via `anipotts@cc`).
+
+this file mirrors `CLAUDE.md` for codex and other openai-convention agents. same repo, same rules, same review contract.
+
+## Review conventions
+
+when reviewing pull requests or issues, read and follow .github/AI_REVIEW_RUBRIC.md exactly. four buckets (blocking / apply / discuss / dismissed), exact output format, auto-dismiss list for voice-conflicting style nits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+<!-- tested with: claude code v2.1.118 -->
+
 # claude-code-tips
 
 personal claude code setup, open source. hooks, example agents/commands, opinionated docs. marketplace name: `cc` (install via `anipotts@cc`).
@@ -37,3 +39,7 @@ personal claude code setup, open source. hooks, example agents/commands, opinion
 - `content/` is GITIGNORED · personal drafts, never commit
 - `data/` is GITIGNORED · local mining data, never commit
 - private dev files live in `handoffs/` and stay local
+
+## Review conventions
+
+when reviewing pull requests or issues, read and follow .github/AI_REVIEW_RUBRIC.md exactly. four buckets (blocking / apply / discuss / dismissed), exact output format, auto-dismiss list for voice-conflicting style nits.

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -8,10 +8,19 @@ every pull request gets reviewed by two ai reviewers (claude, codex) and a human
 
 we replaced coderabbit because its review style kept fighting the repo's lowercase-casual voice and generated high-volume low-signal nits (capitalization, em-dash insertion, marketing adjectives). the replacement is structured, opinionated, and consistent: two reviewers reading the same rubric, lanes split so they rarely duplicate, output in a fixed format that dedupes cleanly.
 
+## auth model: github apps, not api keys
+
+both reviewers ride on github app integrations. no repo secrets, no per-token billing, no curl plumbing to maintain. the workflow posts a single comment that `@mention`s each app; the apps respond using the canonical rubric.
+
+- **claude code github app**: install at [github.com/apps/claude](https://github.com/apps/claude). ties the response bot to the maintainer's claude max subscription.
+- **openai codex github app**: install from the openai codex integrations page (repo settings -> integrations). ties the response bot to the maintainer's chatgpt plus subscription.
+
+if an app is not installed on this repo, the mention sits unanswered. that is not a ci failure; it is just silence. the workflow exits green either way.
+
 ## the team
 
-- **claude** (anthropic api, via `anthropics/claude-code-action`): prose, voice, api/contract shape, skill + hook + plugin surface correctness, tests for public paths.
-- **codex** (openai responses api, o3-mini default): bugs, security, type/shell correctness, dependency hygiene, ci config, shell script robustness.
+- **claude** (via the claude code github app): prose, voice, api/contract shape, skill + hook + plugin surface correctness, tests for public paths.
+- **codex** (via the openai codex github app): bugs, security, type/shell correctness, dependency hygiene, ci config, shell script robustness.
 - **human**: final merge call, trade-offs the bots flagged as discuss, anything that needs context the bots don't have.
 
 ## the rubric
@@ -22,6 +31,7 @@ canonical contract: [.github/AI_REVIEW_RUBRIC.md](../.github/AI_REVIEW_RUBRIC.md
 - the output format (one comment per reviewer, exact shape)
 - the voice + style rules (auto-dismiss list)
 - the lane split (claude vs codex focus)
+- the issue-triage format (category + priority + next steps)
 
 changing the rubric changes how every pr gets reviewed. edits to the rubric ship with a changelog entry.
 
@@ -30,19 +40,19 @@ changing the rubric changes how every pr gets reviewed. edits to the rubric ship
 file: [.github/workflows/ai-review.yml](../.github/workflows/ai-review.yml)
 
 triggers:
-- pull_request opened, synchronize, reopened, ready_for_review (draft prs skipped)
+
+- pull_request opened, ready_for_review (draft prs skipped)
 - issues opened (claude only, codex focuses on code)
 - workflow_dispatch for manual re-review
 
-each reviewer runs as a separate job. both read the rubric. both post a single pr comment. output format is identical, so skimming the two reviews side by side is fast.
+on each trigger the workflow posts one comment. pr comments `@mention` both `@claude` and `@codex` and link the rubric. issue comments `@mention` `@claude` only. the apps do the reading and respond inline.
 
-## secrets required
+a guard skips posting if the workflow already `@mention`ed `@claude` on the pr within the last 7 days. that prevents re-mention loops if the pr flips between draft and ready multiple times or gets manually re-dispatched.
 
-- `ANTHROPIC_API_KEY` for claude
-- `OPENAI_API_KEY` for codex
-- `GITHUB_TOKEN` (default) for posting comments
+## repo secrets
 
-set both in repo settings -> secrets and variables -> actions.
+- `GITHUB_TOKEN` (default, provided by actions): used to post the `@mention` comment.
+- no provider api keys are required. advanced users who want to bypass the apps and call provider apis directly can fork this workflow and add their own secrets, but the default path does not need them.
 
 ## what the bots do not do
 
@@ -77,8 +87,13 @@ these fight the voice and the abstractable-pattern test that tips are held to. a
 
 edit `.github/workflows/ai-review.yml`:
 
-- remove the `claude-review` job to stop claude reviews.
-- remove the `codex-review` job to stop codex reviews.
+- drop `@claude` from the pr comment body to stop claude reviews.
+- drop `@codex` from the pr comment body to stop codex reviews.
 - set the whole workflow to `on: workflow_dispatch` only for manual-only mode.
+- or uninstall the github app under repo settings -> integrations.
 
 removing coderabbit entirely: the repo-level `.coderabbit.yaml` disables auto-reviews. full app uninstall is done in github repo settings under integrations -> installed github apps -> coderabbit -> configure -> uninstall. that page is behind auth so no link here.
+
+## advanced: bypassing the apps
+
+if you prefer to call provider apis directly (cost visibility, custom model choice, stricter rate control), fork `.github/workflows/ai-review.yml`, add your own provider secrets under repo settings -> secrets and variables -> actions, and replace the mention-comment step with a direct api call. that path is unsupported here; the default repo assumes the app-based flow.


### PR DESCRIPTION
## summary

- both pr reviewers (claude + codex) now ride on github app integrations tied to the maintainer's claude max + chatgpt plus subscriptions. no per-token billing, no repo secrets required.
- workflow posts a single comment per pr `@mention`ing `@claude` and `@codex` with a pointer to [.github/AI_REVIEW_RUBRIC.md](.github/AI_REVIEW_RUBRIC.md). each app responds in the exact output shape the rubric defines.
- issues: opened gets a claude-only triage `@mention` using the new "issue triage" rubric section (category + priority + three next steps).
- guard rail: skip if the workflow has already `@mention`ed `@claude` on this pr within the last 7 days, to avoid re-mention loops on manual dispatch or draft-to-ready flips.
- docs: [docs/review-process.md](docs/review-process.md) rewritten for the github-app auth model; provider-api-key path moved to an "advanced" footnote.
- new [AGENTS.md](AGENTS.md) + appended review-conventions section to [CLAUDE.md](CLAUDE.md) so both ecosystems point at the same rubric.

if an app is not installed, the `@mention` sits unanswered and ci stays green. cost: zero.

## test plan

- [ ] install the claude code github app ([github.com/apps/claude](https://github.com/apps/claude)) on this repo
- [ ] install the openai codex github app on this repo (repo settings -> integrations)
- [ ] `workflow_dispatch` this workflow against an existing pr and verify the `@mention` comment posts once and both apps respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)