### PR TITLE
fix(cc): move launcher into bin/launch.sh, drop ${OS}/${ARCH} from manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "claude code plugins by ani potts: session awareness, usage mining, and tools.",
-    "version": "2.3.0"
+    "version": "2.3.1"
   },
   "plugins": [
     {

--- a/plugins/cc/.claude-plugin/plugin.json
+++ b/plugins/cc/.claude-plugin/plugin.json
@@ -1,14 +1,13 @@
 {
   "name": "cc",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Session mesh for Claude Code. Email-cc semantics: every session stays informed of what its siblings are doing, with file-overlap alerts that prevent two agents silently clobbering the same file. Includes the time subsystem (rule, hook, /time-* skills).",
   "author": { "name": "Ani Potts", "url": "https://github.com/anipotts" },
   "repository": "https://github.com/anipotts/claude-code-tips",
   "license": "MIT",
   "mcpServers": {
     "cc": {
-      "command": "bash",
-      "args": ["-c", "ARCH=$(uname -m | sed 's/x86_64/x64/'); OS=$(uname -s | tr A-Z a-z); BIN=\"${CLAUDE_PLUGIN_ROOT}/dist/cc-server-${OS}-${ARCH}\"; if [ -x \"$BIN\" ]; then exec \"$BIN\"; fi; if [ ! -d \"${CLAUDE_PLUGIN_ROOT}/node_modules\" ]; then ln -sfn \"${CLAUDE_PLUGIN_DATA}/node_modules\" \"${CLAUDE_PLUGIN_ROOT}/node_modules\" 2>/dev/null || (cd \"${CLAUDE_PLUGIN_ROOT}\" && bun install --silent); fi; exec bun \"${CLAUDE_PLUGIN_ROOT}/server.ts\""]
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/launch.sh"
     }
   },
   "channels": [{ "server": "cc" }]

--- a/plugins/cc/bin/launch.sh
+++ b/plugins/cc/bin/launch.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# tested with: claude code v2.1.118
+# launcher for the cc MCP server.
+#
+# claude code parses ${VAR} substitutions in plugin.json args before
+# executing the command, so dynamic shell logic must live in a script
+# (where variables are local to bash, not the manifest).
+#
+# preference order:
+#   1. compiled binary at dist/cc-server-${os}-${arch} (zero install)
+#   2. node_modules already present in plugin root → exec via bun
+#   3. fall through to a `bun install` then exec via bun
+#
+# the source path always works; binaries are an opt-in optimization.
+set -eo pipefail
+
+ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+DATA="${CLAUDE_PLUGIN_DATA:-}"
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+  x86_64) ARCH=x64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) ARCH="$ARCH_RAW" ;;
+esac
+
+BIN="$ROOT/dist/cc-server-${OS}-${ARCH}"
+if [ -x "$BIN" ]; then
+  exec "$BIN"
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "cc plugin: bun runtime not found on PATH. install: curl -fsSL https://bun.sh/install | bash" >&2
+  exit 1
+fi
+
+if [ ! -d "$ROOT/node_modules" ]; then
+  if [ -n "$DATA" ] && [ -d "$DATA/node_modules" ]; then
+    ln -sfn "$DATA/node_modules" "$ROOT/node_modules" 2>/dev/null || true
+  fi
+fi
+
+if [ ! -d "$ROOT/node_modules" ]; then
+  (cd "$ROOT" && bun install --silent)
+fi
+
+exec bun "$ROOT/server.ts"

--- a/plugins/cc/server.ts
+++ b/plugins/cc/server.ts
@@ -531,7 +531,7 @@ const tool = {
 };
 
 const server = new Server(
-  { name: "cc", version: "2.3.0" },
+  { name: "cc", version: "2.3.1" },
   { capabilities: { tools: {}, experimental: { "claude/channel": {} } } },
 );
 


### PR DESCRIPTION
## Summary

Closes the `Invalid MCP server config for "cc": Missing environment variables: OS, ARCH` error end users hit when installing v2.3.0.

## Cause

Claude Code substitutes `${VAR}` tokens in `plugin.json` `mcpServers` args before exec, looking each up in the parent environment. v2.3.0 used `${OS}` and `${ARCH}` as bash locals (assigned via `uname` on the same line), but the manifest parser never reaches the bash; it sees unresolved tokens and rejects the config.

## Fix

- New `plugins/cc/bin/launch.sh` holds the launcher logic. Variables are local to bash, not the manifest. Binary preference + node_modules fallback + fresh `bun install` all live there.
- `plugin.json` `mcpServers.cc.command` becomes `${CLAUDE_PLUGIN_ROOT}/bin/launch.sh`, no args, no shell tokens. Only `${CLAUDE_PLUGIN_ROOT}` is referenced and Claude Code provides that.
- Bumps to 2.3.1 in plugin.json, server.ts, marketplace.json.

## Test plan

- [x] `launch.sh` returns `serverInfo: { name: "cc", version: "2.3.1" }` to a fresh `initialize` request when invoked directly with `CLAUDE_PLUGIN_ROOT` set.
- [ ] reviewer: install/update plugin, verify no missing-env-var error, `/cc:sessions` returns live sessions.