### PR TITLE
fix(cc): harden launcher PATH + revert manifest to bash+args form

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "claude code plugins by ani potts: session awareness, usage mining, and tools.",
-    "version": "2.3.1"
+    "version": "2.3.2"
   },
   "plugins": [
     {

--- a/plugins/cc/.claude-plugin/plugin.json
+++ b/plugins/cc/.claude-plugin/plugin.json
@@ -1,13 +1,14 @@
 {
   "name": "cc",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Session mesh for Claude Code. Email-cc semantics: every session stays informed of what its siblings are doing, with file-overlap alerts that prevent two agents silently clobbering the same file. Includes the time subsystem (rule, hook, /time-* skills).",
   "author": { "name": "Ani Potts", "url": "https://github.com/anipotts" },
   "repository": "https://github.com/anipotts/claude-code-tips",
   "license": "MIT",
   "mcpServers": {
     "cc": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/launch.sh"
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/bin/launch.sh"]
     }
   },
   "channels": [{ "server": "cc" }]

--- a/plugins/cc/bin/launch.sh
+++ b/plugins/cc/bin/launch.sh
@@ -14,6 +14,11 @@
 # the source path always works; binaries are an opt-in optimization.
 set -eo pipefail
 
+# claude code may spawn child processes with a stripped PATH that omits
+# the homebrew + bun install dirs. prepend the canonical install paths
+# so we find bun regardless of how cc was launched.
+export PATH="${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
 ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 DATA="${CLAUDE_PLUGIN_DATA:-}"
 

--- a/plugins/cc/server.ts
+++ b/plugins/cc/server.ts
@@ -531,7 +531,7 @@ const tool = {
 };
 
 const server = new Server(
-  { name: "cc", version: "2.3.1" },
+  { name: "cc", version: "2.3.2" },
   { capabilities: { tools: {}, experimental: { "claude/channel": {} } } },
 );
 


### PR DESCRIPTION
## Summary

Fixes the lingering "MCP server 'cc' not connected" error end users hit on v2.3.1 even after fresh install + reload.

## Two real causes

1. **Stripped PATH in CC's spawned child env.** Claude Code spawns plugin MCP servers with a minimal PATH that omits `$HOME/.bun/bin` and homebrew dirs. `launch.sh` ran `command -v bun`, found nothing, exited with the "bun not found" error. CC treats SessionStart hook failures as non-blocking and silently discards stderr, so the user only sees "MCP server 'cc' not connected".
2. **Direct-executable command form.** `command: "${CLAUDE_PLUGIN_ROOT}/bin/launch.sh"` with no args appears to be flakier across CC versions than `command: "bash"` + `args: [script]`. Reverted to the safer form.

## Fix

- `launch.sh` prepends `$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin` to PATH unconditionally before any `command -v` check.
- `plugin.json` uses `command: "bash"`, `args: ["${CLAUDE_PLUGIN_ROOT}/bin/launch.sh"]`.
- 2.3.1 → 2.3.2 in plugin.json, server.ts, marketplace.json.

## Test plan

- [x] `env -i HOME=$HOME bash launch.sh` (stripped PATH) returns `serverInfo: { name: "cc", version: "2.3.2" }` cleanly.
- [ ] reviewer: update plugin, restart CC, verify SessionStart no longer errors and `/cc:sessions` works.