### PR TITLE
fix(cc)!: resolve session identity via parent-pid walk (CC doesn't pass CLAUDE_SESSION_ID)

### DIFF
--- a/plugins/cc/server.ts
+++ b/plugins/cc/server.ts
@@ -73,8 +73,90 @@ const TOPICS_DIR = path.join(CC_DIR, "topics");
 const QUESTIONS_DIR = path.join(CC_DIR, "questions");
 const DB_PATH = path.join(CC_DIR, "sessions.db");
 
-const MY_SESSION_ID = process.env.CLAUDE_SESSION_ID || "";
-const MY_CWD = process.cwd();
+// --- session identity resolution -------------------------------------------
+// CC v2.1.121 does not pass CLAUDE_SESSION_ID to MCP child processes (verified
+// 2026-04-28: env passed includes CLAUDE_PLUGIN_DATA, CLAUDE_CODE_*, but not
+// CLAUDE_SESSION_ID). However CC writes a per-pid metadata file to
+// ~/.claude/sessions/<pid>.json containing { sessionId, cwd, kind, ... } for
+// every interactive CC process. We resolve identity by walking up the parent
+// process chain looking for a pid whose session file exists.
+//
+// Why walk up: the MCP child's direct ppid is usually a shell or the bun
+// runner, not the CC parent. The CC process is one or two levels further up.
+// Stop at depth 8 to avoid infinite loops on weird process trees.
+//
+// Fallback: if the walk fails (orphaned process, non-interactive entrypoint,
+// or session file ENOENT), generate a UUID4 so the server can still register
+// itself. Marked with `kind: "synthetic"` in the row so we know it's not a
+// real CC session.
+import { execSync, spawnSync } from "node:child_process";
+
+type ResolvedIdentity = {
+  sessionId: string;
+  cwd: string;
+  kind: string;
+};
+
+function readSessionFile(pid: number): ResolvedIdentity | null {
+  const p = path.join(CLAUDE_DIR, "sessions", `${pid}.json`);
+  if (!fs.existsSync(p)) return null;
+  try {
+    const raw = JSON.parse(fs.readFileSync(p, "utf-8")) as {
+      sessionId?: string;
+      cwd?: string;
+      kind?: string;
+    };
+    if (!raw.sessionId) return null;
+    return {
+      sessionId: raw.sessionId,
+      cwd: raw.cwd || process.cwd(),
+      kind: raw.kind || "interactive",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getParentPid(pid: number): number | null {
+  try {
+    const out = execSync(`ps -o ppid= -p ${pid}`, { encoding: "utf-8", timeout: 1000 });
+    const ppid = parseInt(out.trim(), 10);
+    return Number.isFinite(ppid) && ppid > 0 ? ppid : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveIdentity(): ResolvedIdentity {
+  // 1. Honor explicit env override (rare, but tests + future CC versions may set it).
+  const envId = process.env.CLAUDE_SESSION_ID;
+  if (envId) {
+    return { sessionId: envId, cwd: process.cwd(), kind: "env" };
+  }
+  // 2. Walk parent chain up to 8 hops; first ancestor with a CC session file wins.
+  let pid: number | null = process.pid;
+  for (let depth = 0; depth < 8 && pid !== null; depth++) {
+    const ident = readSessionFile(pid);
+    if (ident) {
+      process.stderr.write(
+        `cc: identity resolved via /.claude/sessions/${pid}.json (depth ${depth}, sid ${ident.sessionId.slice(0, 8)}, cwd ${ident.cwd})\n`,
+      );
+      return ident;
+    }
+    pid = getParentPid(pid);
+  }
+  // 3. Synthetic fallback. Better to register a row with a fresh id than be invisible.
+  const synthetic = `synthetic-${randomBytes(8).toString("hex")}`;
+  process.stderr.write(
+    `cc: WARNING -- no parent CC session file found; using synthetic id ${synthetic.slice(0, 16)}. The mesh will not see this session as a 'real' peer of any other CC instance.\n`,
+  );
+  return { sessionId: synthetic, cwd: process.cwd(), kind: "synthetic" };
+}
+
+const MY_IDENTITY = resolveIdentity();
+const MY_SESSION_ID = MY_IDENTITY.sessionId;
+const MY_CWD = MY_IDENTITY.cwd;
+const MY_KIND = MY_IDENTITY.kind;
 const MY_PID = process.pid;
 
 // --- env-driven config ---
@@ -127,7 +209,6 @@ const MY_CWD_BASENAME = path.basename(MY_CWD) || MY_SHORT_ID;
 // sessions.* and recent_files.* columns the file-overlap detector reads.
 // Caching for the 60s window between heartbeats means a branch switch
 // shows up to peers within ~30-60s, which is fine for awareness.
-import { spawnSync } from "node:child_process";
 
 type GitContext = {
   branch: string | null;


### PR DESCRIPTION
## TL;DR

cc has been silently non-functional for the entire mesh dimension since v2: every cc_sessions call returns \`[]\`, every cc_send / cc_check fails with \"CLAUDE_SESSION_ID not set; most verbs disabled.\" Verified empirically that Claude Code v2.1.121 does NOT pass CLAUDE_SESSION_ID to MCP child processes. The fix walks the parent process chain to find the CC session metadata file CC writes at \`~/.claude/sessions/<pid>.json\`.

## Root cause

```
const MY_SESSION_ID = process.env.CLAUDE_SESSION_ID || \"\";  // always \"\"

if (MY_SESSION_ID) {                                          // skipped
  db.prepare('INSERT INTO sessions ...').run(...);            // never runs
}
```

The \`if (MY_SESSION_ID)\` gate is the choke point. Without a session id we never write a row, the mesh never has a self to report, and every other verb that requires identity bails with the visible error.

CC writes per-pid metadata that we can read instead:

```json
{
  \"pid\": 88724,
  \"sessionId\": \"488def84-9b84-4c25-a7dd-00ef231ea06b\",
  \"cwd\": \"/Users/anipotts/Code/active/claude-code-tips\",
  \"kind\": \"interactive\",
  \"version\": \"2.1.121\"
}
```

The MCP child's direct \`ppid\` is usually a bun runner / shell, not CC itself. CC is one or two parent levels further up. We walk up to 8 hops, reading the session file at each pid, and adopt the first one we find.

## Two bugs, one fix

1. **Empty sessions.db** — gated by missing \`CLAUDE_SESSION_ID\`. Now resolved by walk.
2. **Wrong cwd everywhere** — \`process.cwd()\` was the plugin root because \`.mcp.json\` launches \`bun run --cwd \${CLAUDE_PLUGIN_ROOT}\`. So \`cwd_basename\` showed \"cc\" for every peer regardless of project. Now adopted from the same session file the walk found.

## Fallback

If the walk fails completely (orphan process, weird entrypoint, ENOENT on every parent), generate \`synthetic-<8 hex>\` so the server still registers + returns from cc_sessions in degraded mode. Marked with \`kind: 'synthetic'\` and a stderr warning.

## Verification

```bash
$ unset CLAUDE_SESSION_ID
$ bun server.ts < <(...)
cc: identity resolved via /.claude/sessions/88724.json (depth 3,
    sid 488def84, cwd /Users/anipotts/Code/active/claude-code-tips)

> cc_sessions => {
    \"sessions\": [{
      \"id\": \"488def84-9b84-4c25-a7dd-00ef231ea06b\",
      \"short_id\": \"488def84\",
      \"cwd_basename\": \"claude-code-tips\",  <-- real project, not 'cc'
      \"cwd\": \"/Users/anipotts/Code/active/claude-code-tips\"
    }]
  }
```

## Test plan

- [x] without CLAUDE_SESSION_ID env, server resolves identity via parent walk
- [x] cwd_basename reflects real project, not plugin dir
- [x] sessions.db row written on boot
- [x] cc_sessions returns the live row
- [ ] user runs \`/reload-plugins\` after this merges; verifies multi-session mesh actually shows peers across CC sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)