### PR TITLE
chore(cc): bump 3.0.0 -> 3.0.1 to invalidate stale plugin cache

### DIFF
--- a/plugins/cc/.claude-plugin/plugin.json
+++ b/plugins/cc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Session mesh for Claude Code. Email-cc semantics: every session stays informed of what its siblings are doing, with file-overlap alerts that prevent two agents silently clobbering the same file.",
   "author": { "name": "Ani Potts", "url": "https://github.com/anipotts" },
   "repository": "https://github.com/anipotts/claude-code-tips",

--- a/plugins/cc/package.json
+++ b/plugins/cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "bin": "./server.ts",


### PR DESCRIPTION
## Why

PR #60's session-identity fix landed in main but is **not running** on installed instances. CC caches plugins at `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` keyed on plugin version. v3.0.0 was cached BEFORE #60 merged. Pulling main into the marketplace clone updates the clone (`~/.claude/plugins/marketplaces/cc/plugins/cc/`) but not the cache.

Verified empirically:

```
$ grep -c 'identity resolved via' \
    ~/.claude/plugins/cache/cc/cc/3.0.0/server.ts             # 0  <-- stale
$ grep -c 'identity resolved via' \
    ~/.claude/plugins/marketplaces/cc/plugins/cc/server.ts    # 1  <-- fix present
$ diff -u <stale_cache> <fresh_clone>                        # 87 lines of diff
```

Bumping the version forces CC to rebuild the cache from the marketplace clone on next plugin load.

## Test plan

- [ ] After merge: `/reload-plugins` should rebuild the cache at `~/.claude/plugins/cache/cc/cc/3.0.1/` with the fixed server.ts
- [ ] `/cc:sessions` returns the live session row (not empty)
- [ ] stderr (visible in CC's debug log) shows `cc: identity resolved via /.claude/sessions/<pid>.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)