### PR TITLE
chore(cc): bump @modelcontextprotocol/sdk to ^1.29.0

### DIFF
--- a/plugins/cc/bun.lock
+++ b/plugins/cc/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cc",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.0",
       },

--- a/plugins/cc/package.json
+++ b/plugins/cc/package.json
@@ -10,7 +10,7 @@
     "test": "bun test tests/"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.0"
   },


### PR DESCRIPTION
## summary

closes #88. bumps \`@modelcontextprotocol/sdk\` in \`plugins/cc/package.json\` from \`^1.12.1\` to \`^1.29.0\` (latest published).

bun update only touched the sdk and lockfile. zod and zod-to-json-schema were left where they are.

## verification

surface that the cc server uses still works:

- \`Server\`, \`StdioServerTransport\`, \`types.js\` imports unchanged
- \`capabilities.experimental\` still accepted; the \`claude/channel\` experimental key round-trips through the smoke initialize response
- \`server.notification(...)\` shape unchanged in the inbox watcher (\`plugins/cc/server.ts:1062\`)

## test plan

- [x] \`bun run smoke\` returns the expected initialize response with the experimental capability and the shutdown line
- [x] \`bun test plugins/cc/tests\`: 35 pass, 0 fail
- [x] no other deps changed (only \`plugins/cc/package.json\` and \`plugins/cc/bun.lock\`)

note: skipped the changelog entry per the issue's acceptance criteria ("after CHANGELOG issue lands").