### PR TITLE
feat(cc): switch action JSON Schema from anyOf to oneOf

### DIFF
--- a/plugins/cc/lib/action.ts
+++ b/plugins/cc/lib/action.ts
@@ -108,12 +108,18 @@ const _raw = zodToJsonSchema(ActionSchema, {
 });
 
 // zod-to-json-schema wraps the result in {$schema, ...rest}. We want the rest.
-const { $schema: _drop, ...stripped } = _raw as { $schema?: string } & Record<
-  string,
-  unknown
->;
+const { $schema: _drop, anyOf: _branches, ...stripped } = _raw as {
+  $schema?: string;
+  anyOf?: unknown[];
+} & Record<string, unknown>;
 
-export const ACTION_JSON_SCHEMA = stripped as Record<string, unknown>;
+// Discriminated unions SHOULD use `oneOf` per JSON Schema 2020-12 + OpenAPI.
+// Some MCP clients treat `anyOf` permissively (multi-branch match) whereas
+// `oneOf` is exclusive -- closer to the discriminated-union semantic.
+const withOneOf =
+  _branches !== undefined ? { ...stripped, oneOf: _branches } : stripped;
+
+export const ACTION_JSON_SCHEMA = withOneOf as Record<string, unknown>;
 
 // --- runtime helpers --------------------------------------------------------
 

--- a/plugins/cc/tests/action.test.ts
+++ b/plugins/cc/tests/action.test.ts
@@ -107,9 +107,13 @@ describe("ActionSchema (zod source of truth)", () => {
 });
 
 describe("ACTION_JSON_SCHEMA (model-facing)", () => {
-  it("is an anyOf of one branch per action", () => {
-    expect(ACTION_JSON_SCHEMA.anyOf).toBeDefined();
-    expect((ACTION_JSON_SCHEMA.anyOf as unknown[]).length).toBe(4);
+  it("is a oneOf of one branch per action", () => {
+    expect(ACTION_JSON_SCHEMA.oneOf).toBeDefined();
+    expect((ACTION_JSON_SCHEMA.oneOf as unknown[]).length).toBe(4);
+  });
+
+  it("does not include anyOf (post-processed to oneOf)", () => {
+    expect(ACTION_JSON_SCHEMA.anyOf).toBeUndefined();
   });
 
   it("does not include $schema (cleaner bytes for prompt cache)", () => {
@@ -126,7 +130,7 @@ describe("ACTION_JSON_SCHEMA (model-facing)", () => {
   });
 
   it("each branch enforces its action discriminator as const", () => {
-    for (const branch of ACTION_JSON_SCHEMA.anyOf as Array<Record<string, unknown>>) {
+    for (const branch of ACTION_JSON_SCHEMA.oneOf as Array<Record<string, unknown>>) {
       const props = branch.properties as Record<string, { const?: string }>;
       expect(props.action.const).toBeDefined();
       expect(typeof props.action.const).toBe("string");


### PR DESCRIPTION
Resolves #82.

`zodToJsonSchema(...)` with `target: "jsonSchema7"` emits an `anyOf` for the discriminated union, but the file's own comment + tool-surface language already describe the schema as a `oneOf`. The issue notes:

1. JSON Schema 2020-12 says discriminated unions SHOULD use `oneOf`
2. OpenAPI tooling uses `oneOf` + `discriminator`
3. Some MCP clients treat `anyOf` permissively whereas `oneOf` is exclusive

## Approach

Post-process the generator output to rename `anyOf` -> `oneOf` rather than switching the generator target to `openApi3`. The post-process keeps every other byte stable, which preserves the existing byte-stability invariant that the `ACTION_JSON_SCHEMA` is cached at module load and reused across sessions for prompt-cache hits. Switching the target would also alter nullable handling and ref behavior.

## Changes

- `plugins/cc/lib/action.ts`: extract `anyOf` from the generator output and re-emit as `oneOf` via a single object spread.
- `plugins/cc/tests/action.test.ts`: update assertions to reference `oneOf` (the byte-stability test continues to compare `JSON.stringify(ACTION_JSON_SCHEMA)` across re-imports).

`bun test tests/action.test.ts` passes (19/19).

## Acceptance

- [x] `tools/list` inputSchema uses `oneOf` (not `anyOf`)
- [x] Existing tests still pass (19/19)
- [x] Byte-stability snapshot test continues to pass