### PR TITLE
feat(cc)!: wave A.6 — cold-start UX, ride CC's native primitives

### DIFF
--- a/plugins/cc/hooks/hooks.json
+++ b/plugins/cc/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit|NotebookEdit",

--- a/plugins/cc/hooks/session-start.ts
+++ b/plugins/cc/hooks/session-start.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+// tested with: claude code v2.1.132
+//
+// SessionStart hook for cc plugin (v3.3 cold-start fix).
+//
+// Fires when a Claude Code session starts. Registers the session in cc's
+// sessions.db so peers see this session in their roster *before* it makes
+// its first cc tool call. Without this, a session is invisible until it
+// happens to invoke cc(action='...') — the install-trial UX bug.
+//
+// Read JSON from stdin (CC passes session_id, cwd, etc.). Derive git context
+// locally. Insert/upsert the row. The cc MCP server's own boot path also
+// writes this row; ON CONFLICT(id) DO UPDATE keeps both paths idempotent.
+//
+// Fail-soft: any exception → exit 0. Hooks must NEVER block session startup.
+
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function gitOutput(args: string[], cwd: string): string | null {
+  try {
+    const r = spawnSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      timeout: 1500,
+    });
+    return r.status === 0 ? r.stdout.trim() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+function projectRootFromCwd(cwd: string): string | null {
+  // Match server.ts:readGitContext exactly. --git-common-dir returns:
+  //   ".git" (repo root), "<abs>/.git", "../.git", "../../.git/worktrees/<n>"
+  // Strip optional-leading-slash + .git[/worktrees/<name>]; resolve relative
+  // results against cwd. Empty after strip means cwd is the repo root.
+  const out = gitOutput(["rev-parse", "--git-common-dir"], cwd);
+  if (!out) return null;
+  const stripped = out.replace(/(?:^|\/)\.git(?:\/worktrees\/[^/]+)?$/, "");
+  return path.isAbsolute(stripped) ? stripped : path.resolve(cwd, stripped);
+}
+
+async function main(): Promise<void> {
+  let payload: Record<string, unknown> = {};
+  try {
+    const raw = await Bun.stdin.text();
+    if (raw) payload = JSON.parse(raw);
+  } catch {
+    return; // unparseable stdin
+  }
+
+  const sid =
+    (typeof payload.session_id === "string" && payload.session_id) ||
+    process.env.CLAUDE_CODE_SESSION_ID ||
+    "";
+  if (!sid) return;
+
+  const cwd =
+    (typeof payload.cwd === "string" && payload.cwd) || process.cwd();
+
+  // cc state dir resolution mirrors server.ts.
+  const claudeDir =
+    process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  const ccDir =
+    process.env.CC_STATE_DIR || path.join(claudeDir, "channels", "cc");
+  const dbPath = path.join(ccDir, "sessions.db");
+
+  // cc db not initialized yet — first install. The MCP server's boot path
+  // creates the schema; on the next session start the hook will populate.
+  if (!fs.existsSync(dbPath)) return;
+
+  const branch = gitOutput(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  const worktree = gitOutput(["rev-parse", "--show-toplevel"], cwd);
+  const projectRoot = projectRootFromCwd(cwd);
+  const nowMs = Date.now();
+  const pid = typeof process.ppid === "number" ? process.ppid : 0;
+
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readwrite: true });
+
+    // Same INSERT...ON CONFLICT shape as server.ts self-register block.
+    // started_at_ms only set on initial insert; subsequent UPSERTs keep the
+    // original value (DO UPDATE excludes started_at_ms).
+    db.prepare(
+      `INSERT INTO sessions (id, cwd, project_root, branch, worktree_root, pid, started_at_ms, last_seen_at_ms, ended_at_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+       ON CONFLICT(id) DO UPDATE SET
+         cwd = excluded.cwd,
+         project_root = excluded.project_root,
+         branch = excluded.branch,
+         worktree_root = excluded.worktree_root,
+         pid = excluded.pid,
+         last_seen_at_ms = excluded.last_seen_at_ms,
+         ended_at_ms = NULL`,
+    ).run(sid, cwd, projectRoot, branch, worktree, pid, nowMs, nowMs);
+  } catch {
+    // schema mismatch / db locked / permission — fail soft
+  } finally {
+    db?.close();
+  }
+}
+
+await main();

--- a/plugins/cc/lib/action.ts
+++ b/plugins/cc/lib/action.ts
@@ -100,9 +100,12 @@ export const ACTION_NAMES: readonly ActionName[] = [
 // Kept terse: this string lands in every system prompt for every cc session.
 // The model gets full verb routing from skills/sessions/SKILL.md; this string
 // only needs to convey what the tool *is*, the four actions, and the push
-// guarantee for DM arrival.
+// guarantee for DM arrival. Disambiguating tokens up front so ToolSearch on
+// "session mesh" / "peer messaging" / "multi-agent coordination" matches — a
+// bare "cc" collides with Slack mention syntax, MCP server prefixes, and AWS
+// service codes.
 export const TOOL_DESCRIPTION =
-  "Coordinate peer Claude Code sessions on this machine. " +
+  "cc — Claude Code session mesh, peer messaging, multi-agent coordination on this machine. " +
   "Actions: sessions (list peers), send (DM peer), announce (broadcast status), check (pull digest). " +
   "DM arrival is push-delivered via the channel; polling check is rarely needed. " +
   "Default scope is the current git project_root.";

--- a/plugins/cc/lib/render.ts
+++ b/plugins/cc/lib/render.ts
@@ -26,6 +26,10 @@ export type SessionDigest = {
   role?: string | null;
   recent_files: string[];
   last_announce?: { summary: string; age_s: number } | null;
+  // v3.3: false when the peer is visible via ~/.claude/sessions/<pid>.json
+  // but cc's MCP server isn't up in that terminal yet (typical on the first
+  // install before the user reloads other terminals).
+  cc_loaded?: boolean;
 };
 
 export type OverlapAlert = {
@@ -125,14 +129,23 @@ export function renderDigest(d: Digest): string {
 
   if (d.session_digests.length > 0) {
     lines.push("");
-    lines.push("activity:");
+    const ccLoadedCount = d.session_digests.filter(
+      (s) => s.cc_loaded !== false,
+    ).length;
+    const nativeOnlyCount = d.session_digests.length - ccLoadedCount;
+    lines.push(
+      nativeOnlyCount > 0
+        ? `activity (${ccLoadedCount} cc-loaded, ${nativeOnlyCount} need /reload-plugins):`
+        : "activity:",
+    );
     for (const s of d.session_digests) {
       const files = s.recent_files.slice(0, 3).map((f) => shortPath(f)).join(", ");
       const filesStr = files ? ` (${files})` : "";
       const announce = s.last_announce
         ? `: ${previewOf(s.last_announce.summary, 160)} [${formatAge(s.last_announce.age_s)}]`
         : "";
-      lines.push(`- ${s.session} @ ${shortPath(s.cwd)}${filesStr}${announce}`);
+      const marker = s.cc_loaded === false ? " [no cc]" : "";
+      lines.push(`- ${s.session} @ ${shortPath(s.cwd)}${marker}${filesStr}${announce}`);
     }
   }
 

--- a/plugins/cc/server.ts
+++ b/plugins/cc/server.ts
@@ -252,12 +252,14 @@ function readGitContext(cwd: string): GitContext {
   if (commonRes.status === 0) {
     const commonDir = commonRes.stdout.trim();
     // common-dir can be:
+    //   - ".git"                                          primary repo, cwd IS repo root
     //   - "<abs>/.git"                                    primary repo, abs path
     //   - "<abs>/.git/worktrees/<name>"                   linked worktree, abs
     //   - "../.git" / "../../.git"                        primary repo, relative to cwd
     //   - "../../.git/worktrees/<name>"                   linked worktree, relative
-    // Strip /.git[/worktrees/<name>] then resolve relative paths against cwd.
-    const stripped = commonDir.replace(/\/\.git(?:\/worktrees\/[^/]+)?$/, "");
+    // Strip optional leading-slash + .git[/worktrees/<name>], then resolve
+    // any relative result against cwd. Empty result means cwd is repo root.
+    const stripped = commonDir.replace(/(?:^|\/)\.git(?:\/worktrees\/[^/]+)?$/, "");
     project_root = path.isAbsolute(stripped)
       ? stripped
       : path.resolve(cwd, stripped);
@@ -443,24 +445,144 @@ type LiveSessionRow = {
   last_seen_at_ms: number;
   started_at_ms: number;
   project_root: string | null;
+  // v3.3: cc_loaded distinguishes "this peer has cc's MCP server up" (we
+  // have a row in our sessions table for it) from "this peer is live in CC
+  // but cc plugin not yet wired in that terminal" (only a native session
+  // file exists). The install-trial UX needs both visible.
+  cc_loaded: boolean;
+  pid: number | null;
 };
 
-// 200ms TTL: peer state genuinely changes (action calls + transcript activity
-// refresh last_seen, ended_at flips on shutdown), but within a single user
-// turn the answer is stable. Tight window means cross-turn freshness lives.
+type NativeSession = {
+  sessionId: string;
+  cwd: string;
+  pid: number;
+  mtimeMs: number;
+};
+
+// CC drops ~/.claude/sessions/<pid>.json for every live interactive session.
+// We treat that directory as the authoritative service-discovery layer: a
+// session is "live" iff its file exists AND its pid is still alive. cc's
+// own sessions table is a metadata cache layered on top.
+function nativeLiveSessions(): NativeSession[] {
+  const dir = path.join(CLAUDE_DIR, "sessions");
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: NativeSession[] = [];
+  for (const f of entries) {
+    if (!f.endsWith(".json") || f.startsWith(".")) continue;
+    const pid = parseInt(f.replace(/\.json$/, ""), 10);
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    // Liveness check: signal 0 throws if the process is dead. CC may leave
+    // stale session files behind on dirty exit; this filters them out.
+    try {
+      process.kill(pid, 0);
+    } catch {
+      continue;
+    }
+    const fp = path.join(dir, f);
+    try {
+      const stat = fs.statSync(fp);
+      const raw = JSON.parse(fs.readFileSync(fp, "utf-8")) as {
+        sessionId?: string;
+        cwd?: string;
+      };
+      if (!raw.sessionId) continue;
+      out.push({
+        sessionId: raw.sessionId,
+        cwd: raw.cwd || "",
+        pid,
+        mtimeMs: stat.mtimeMs,
+      });
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+// Per-cwd project_root cache for non-cc-loaded peers. cc-loaded peers carry
+// project_root in the sessions row; native-only peers need git resolution
+// to participate in scope filtering. One git invocation per distinct cwd
+// per cc server lifetime is fine.
+const projectRootCache = new Map<string, string | null>();
+function projectRootForCwd(cwd: string): string | null {
+  if (!cwd) return null;
+  const cached = projectRootCache.get(cwd);
+  if (cached !== undefined) return cached;
+  const ctx = readGitContext(cwd);
+  projectRootCache.set(cwd, ctx.project_root);
+  return ctx.project_root;
+}
+
+// 200ms TTL: peer state genuinely changes (action calls + hook activity
+// refresh last_seen, native session files appear/disappear), but within a
+// single user turn the answer is stable. Tight window means cross-turn
+// freshness lives.
 const liveSessionsCache = new TTLCache<"all", LiveSessionRow[]>(200);
 
 function liveSessions(): LiveSessionRow[] {
-  return liveSessionsCache.get("all", () =>
-    db
+  return liveSessionsCache.get("all", () => {
+    const native = nativeLiveSessions();
+    if (native.length === 0) {
+      // No native session files visible (unusual layout). Fall back to
+      // cc-table-only and treat every row as cc_loaded=true (it has to
+      // be — the row exists because cc booted).
+      return (
+        db
+          .prepare(
+            `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root, pid
+             FROM sessions
+             WHERE ended_at_ms IS NULL AND last_seen_at_ms > ?
+             ORDER BY last_seen_at_ms DESC`,
+          )
+          .all(now() - STALE_SESSION_AFTER_MS) as Array<
+          Omit<LiveSessionRow, "cc_loaded">
+        >
+      ).map<LiveSessionRow>((r) => ({ ...r, cc_loaded: true }));
+    }
+    // Cross-reference native sessions with cc table by session_id.
+    const ccRows = db
       .prepare(
-        `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root
+        `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root, pid
          FROM sessions
-         WHERE ended_at_ms IS NULL AND last_seen_at_ms > ?
-         ORDER BY last_seen_at_ms DESC`,
+         WHERE ended_at_ms IS NULL`,
       )
-      .all(now() - STALE_SESSION_AFTER_MS) as LiveSessionRow[],
-  );
+      .all() as Array<Omit<LiveSessionRow, "cc_loaded">>;
+    const ccById = new Map<string, (typeof ccRows)[number]>();
+    for (const r of ccRows) ccById.set(r.id, r);
+
+    return native.map<LiveSessionRow>((n) => {
+      const cc = ccById.get(n.sessionId);
+      if (cc) {
+        return {
+          ...cc,
+          cwd: cc.cwd || n.cwd,
+          last_seen_at_ms: Math.max(cc.last_seen_at_ms, n.mtimeMs),
+          pid: cc.pid ?? n.pid,
+          cc_loaded: true,
+        };
+      }
+      // Native-only peer (cc plugin not wired in that terminal yet).
+      // Synthesize a row from native data; derive project_root via cached
+      // git lookup so scope filtering still works.
+      return {
+        id: n.sessionId,
+        name: "",
+        cwd: n.cwd,
+        role: null,
+        last_seen_at_ms: n.mtimeMs,
+        started_at_ms: n.mtimeMs,
+        project_root: projectRootForCwd(n.cwd),
+        cc_loaded: false,
+        pid: n.pid,
+      };
+    });
+  });
 }
 
 // Project-scoped filter: keep peers in my project_root. If I'm in a non-git
@@ -679,12 +801,16 @@ function computeDigest(opts: { since_ms?: number | null; scope?: "project" | "gl
   // session_digests: one per live peer. v3 identity = "<short-id> @ <cwd-basename>"
   // ('name' column is retained but no longer auto-populated; if a future
   // rename verb writes to it, prefer the user-set name when present.)
+  // v3.3: cc_loaded propagates into the rendered digest so the "no cc"
+  // marker fires on native-only peers (their recent_files are empty and
+  // last_announce is null because the cc plugin never wrote any).
   const sessionDigests = peers.map((p) => ({
     session: p.name || `${p.id.slice(0, 8)} @ ${path.basename(p.cwd)}`,
     cwd: p.cwd,
     role: p.role,
-    recent_files: recentFilesFor(p.id),
-    last_announce: lastAnnounceFor(p.id),
+    recent_files: p.cc_loaded ? recentFilesFor(p.id) : [],
+    last_announce: p.cc_loaded ? lastAnnounceFor(p.id) : null,
+    cc_loaded: p.cc_loaded,
   }));
 
   // file_overlap_alerts: v3 redesign. The v2 design used a 10-minute time
@@ -968,10 +1094,33 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         cwd_basename: path.basename(s.cwd),
         cwd: s.cwd,
         role: s.role ?? null,
-        recent_files: recentFilesFor(s.id),
+        // Native-only peers don't have recent_files (no cc hook fired in
+        // that terminal yet). Surface an empty array, not stale data.
+        recent_files: s.cc_loaded ? recentFilesFor(s.id) : [],
         last_seen_s: Math.max(0, Math.floor((now() - s.last_seen_at_ms) / 1000)),
+        cc_loaded: s.cc_loaded,
       }));
-    return text(JSON.stringify({ sessions: out, scope: action.scope ?? "project" }, null, 2));
+    const ccLoadedCount = out.filter((s) => s.cc_loaded).length;
+    const nativeOnlyCount = out.length - ccLoadedCount;
+    return text(
+      JSON.stringify(
+        {
+          sessions: out,
+          scope: action.scope ?? "project",
+          summary: {
+            total: out.length,
+            cc_loaded: ccLoadedCount,
+            native_only: nativeOnlyCount,
+            hint:
+              nativeOnlyCount > 0
+                ? "native_only peers have a Claude Code session but cc plugin isn't wired yet — they need to restart their terminal once after install."
+                : undefined,
+          },
+        },
+        null,
+        2,
+      ),
+    );
   }
 
   // ---- send ----

--- a/plugins/cc/skills/sessions/SKILL.md
+++ b/plugins/cc/skills/sessions/SKILL.md
@@ -8,13 +8,33 @@ description: |
   "let peers know I'm doing X", "broadcast <status>", "check the cc digest",
   or any cross-session / multi-agent coordination on this machine.
 ---
-<!-- tested with: claude code v2.1.122 -->
+<!-- tested with: claude code v2.1.132 -->
 
 # cc — session mesh
 
 Use the **cc MCP tool** with one of four actions. The tool description in
 your context already documents arg shapes; this skill covers *when* to pick
 which action.
+
+## After a fresh install
+
+The MCP tool is registered when a Claude Code session starts. **The session
+that just ran `/plugin install cc@claude-code-tips` cannot itself call the
+tool until that terminal restarts** — Claude Code doesn't re-poll
+`tools/list` mid-session. New sessions opened after the install pick up the
+tool immediately.
+
+If `mcp__cc__cc` isn't in your tool list:
+
+- Tell the user to open a new terminal and run `claude` there. That session
+  has the tool.
+- For the roster verb only, you can fall back to a direct sqlite read:
+  `sqlite3 ~/.claude/channels/cc/sessions.db "SELECT id, cwd, last_seen_at_ms FROM sessions WHERE ended_at_ms IS NULL ORDER BY last_seen_at_ms DESC"`.
+  This is read-only and only useful for "who's running"; for `send` /
+  `announce` / `check` you need the MCP tool.
+- The cc plugin's SessionStart hook registers every session in the cc table
+  on session start, so peer visibility works regardless of whether the MCP
+  tool is reachable in *this* session.
 
 ## Pick the action
 


### PR DESCRIPTION
## Summary

The 3.2.0 first-install trial exposed five UX bugs rooted in cc fighting Claude Code's native primitives instead of riding them. This wave fixes cold start.

**The architectural pivot:** `~/.claude/sessions/<pid>.json` (CC's own session metadata) is the authoritative service-discovery layer. cc's sessions table is a metadata cache layered on top.

## Bugs fixed

| # | bug | fix |
|---|---|---|
| 1 | roster requires participation, not presence | `liveSessions()` reads native files + `kill -0` liveness, merges with cc table, surfaces `cc_loaded` flag |
| 2 | SessionStart hook missing | new `hooks/session-start.ts` registers row at session start, idempotent UPSERT |
| 3 | MCP unreachable in install session | SKILL.md gains "After a fresh install" section; drops `AskUserQuestion` gate |
| 4 | stale paths | repo audit clean; SKILL stamp bumped to v2.1.132 |
| 5 | ToolSearch ambiguity on bare "cc" | `TOOL_DESCRIPTION` leads with "Claude Code session mesh, peer messaging, multi-agent coordination" |

## What you'll see in `cc(action='sessions')`

```json
{
  "sessions": [
    {"id":"...","cc_loaded":true,"recent_files":[...]},
    {"id":"...","cc_loaded":false,"recent_files":[]}
  ],
  "scope":"project",
  "summary":{
    "total":3,"cc_loaded":1,"native_only":2,
    "hint":"native_only peers have a Claude Code session but cc plugin isn't wired yet — they need to restart their terminal once after install."
  }
}
```

Rendered digest gets a `(1 cc-loaded, 2 need /reload-plugins)` header and `[no cc]` markers on native-only peer lines.

## Latent bug fix included

`readGitContext`'s project_root regex didn't strip bare `.git` (what `git rev-parse --git-common-dir` returns when cwd IS the repo root). Pre-A.6 cc running from a repo root would store `cwd/.git` as project_root, breaking scope filtering. Updated to `(?:^|/)\\.git(?:/worktrees/<n>)?$`. SessionStart hook uses the same regex.

## Test plan

- [x] `bun test tests/` — 36 pass
- [x] `CLAUDE_CODE_SESSION_ID=... bun run smoke` — server boots clean, reports v3.2.0
- [x] SessionStart hook end-to-end: synthetic JSON → `bun hooks/session-start.ts` → row lands with correct project_root from a repo-root cwd
- [x] PostToolUse hook still works (unchanged from A.5)
- [x] `bunx tsc --noEmit` clean

## Breaking?

`!` per conventional commits — `LiveSessionRow` gains `cc_loaded` and `pid` fields; `SessionDigest` gains optional `cc_loaded`. Schema bytes change once on tools/list (one prompt-cache invalidation), then byte-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)