### PR TITLE
fix(cc): add version stamps to CHANGELOG.md + bun-loaders.d.ts

### DIFF
--- a/plugins/cc/CHANGELOG.md
+++ b/plugins/cc/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- tested with: claude code v2.1.132 -->
+
 # Changelog
 
 All notable changes to the cc plugin are documented here. The format follows

--- a/plugins/cc/types/bun-loaders.d.ts
+++ b/plugins/cc/types/bun-loaders.d.ts
@@ -1,3 +1,4 @@
+// tested with: claude code v2.1.132
 // Bun resolves *.sql imports as text content via its built-in loader.
 // tsc has no native concept for this; declare it as a module that exports
 // a string default. db/migrate.ts uses this to embed schema.sql at build time.


### PR DESCRIPTION
Hotfix — #111 auto-merged the initial commit before the version-stamp fix push reached origin. Adds the two missing stamps so the version-stamps workflow stays green on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)