### PR TITLE
feat(cc): wave B — peer intent summary + digest_delta on every cc call

### DIFF
--- a/plugins/cc/.claude-plugin/plugin.json
+++ b/plugins/cc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Session mesh for Claude Code. Email-cc semantics: every session stays informed of what its siblings are doing, with file-overlap alerts that prevent two agents silently clobbering the same file.",
   "author": { "name": "Ani Potts", "url": "https://github.com/anipotts" },
   "repository": "https://github.com/anipotts/claude-code-tips",

--- a/plugins/cc/CHANGELOG.md
+++ b/plugins/cc/CHANGELOG.md
@@ -8,17 +8,35 @@ All notable changes to the cc plugin are documented here. The format follows
 
 ## [Unreleased]
 
+## [3.3.0] — 2026-05-07
+
 ### Added
-- SessionStart hook (`hooks/session-start.ts`) registers every session in cc's
-  table at session start, so peers appear in the roster before they've ever
-  called `cc(...)`. Closes the install-trial UX gap where a session was
-  invisible until first tool call.
-- `liveSessions()` reads `~/.claude/sessions/*.json` (CC's native service-
-  discovery layer) as the authoritative live-peer source. Liveness check is
-  `process.kill(pid, 0)`. cc's own sessions table becomes a metadata cache.
-- `cc_loaded` flag on each peer in `cc(action='sessions')` and rendered
-  digests so the install-time UX surfaces "this session is live but cc plugin
-  isn't wired in that terminal yet."
+- **Wave A.6** — Cold-start UX. `liveSessions()` reads
+  `~/.claude/sessions/*.json` (CC's native service-discovery layer) +
+  `process.kill(pid, 0)` liveness check, merges with cc's sessions table.
+  Native-only peers (cc plugin not wired in their terminal yet) surface
+  with `cc_loaded=false`.
+- **Wave A.6** — SessionStart hook (`hooks/session-start.ts`) registers
+  every session in cc's table at session start. Idempotent UPSERT — both
+  the hook and the cc MCP server's boot path write the row.
+- **Wave A.6** — Per-cwd `project_root` cache for native-only peers, so
+  scope filtering works without forking a git invocation per peer per call.
+- **Wave A.6** — `cc_loaded` flag on each peer in `cc(action='sessions')`
+  and rendered digests; `(N cc-loaded, M need /reload-plugins)` header
+  when both kinds present.
+- **Wave B** — Peer intent summary in roster + digest. Each peer carries
+  `branch`, `summary` (one-line synthesis: latest <30min announcement,
+  else most-recent-touched file basename, else "(idle)"),
+  `last_announce_age_s`, `last_edit_age_s`. Renderer formats as
+  `abcd1234 main · auth.ts (3m ago)` instead of just `abcd1234 @ repo`.
+- **Wave B** — Piggyback `digest_delta` on every action call. When
+  `cc(action='sessions'|'send'|'announce')` runs, the response includes
+  a `digest_delta` block listing new announcements, edited files, peer
+  joins, and peer leaves since the caller's last cc call. Once a delta
+  has been observed, `last_checked_at_ms` advances so subsequent calls
+  don't replay the same events. Zero new infrastructure — no FSWatcher,
+  no relay file, no new hook. Trade-off: delta only fires on the caller's
+  next cc call (vs. true push); acceptable for v1.
 
 ### Changed
 - `TOOL_DESCRIPTION` leads with disambiguating tokens (`Claude Code session
@@ -26,8 +44,8 @@ All notable changes to the cc plugin are documented here. The format follows
   on those phrases. Bare `cc` was colliding with Slack mention syntax, MCP
   server prefixes, and AWS service codes.
 - `SKILL.md` gains an "After a fresh install" section explicitly naming the
-  CC-doesn't-re-poll-tools/list constraint and the workaround. SKILL stamp
-  bumped to 2.1.132.
+  CC-doesn't-re-poll-tools/list constraint and the workaround. Updated
+  for the v3.3 `digest_delta` return shape on every cc call.
 - `readGitContext` `project_root` regex handles bare `.git` returned by
   `git rev-parse --git-common-dir` when cwd IS the repo root. Previously
   computed `cwd/.git` instead of `cwd`. SessionStart hook uses the same fix.
@@ -92,7 +110,8 @@ All notable changes to the cc plugin are documented here. The format follows
 ### Closed issues
 - Prior issues tracked in `BACKLOG.md` (now removed; tracked on GitHub).
 
-[Unreleased]: https://github.com/anipotts/claude-code-tips/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/anipotts/claude-code-tips/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.3.0
 [3.2.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.2.0
 [3.1.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.1.0
 [3.0.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.0.0

--- a/plugins/cc/lib/render.ts
+++ b/plugins/cc/lib/render.ts
@@ -30,6 +30,15 @@ export type SessionDigest = {
   // but cc's MCP server isn't up in that terminal yet (typical on the first
   // install before the user reloads other terminals).
   cc_loaded?: boolean;
+  // v3.4: peer intent summary fields. branch is the peer's current git
+  // branch (null on native-only peers). summary is a one-line synthesis
+  // (latest <30min announcement, else most-recent-touched-file basename,
+  // else "(idle)"). last_edit_age_s + last_announce_age_s let the renderer
+  // pick the freshest signal for the parenthetical age.
+  branch?: string | null;
+  summary?: string | null;
+  last_edit_age_s?: number | null;
+  last_announce_age_s?: number | null;
 };
 
 export type OverlapAlert = {
@@ -139,13 +148,22 @@ export function renderDigest(d: Digest): string {
         : "activity:",
     );
     for (const s of d.session_digests) {
-      const files = s.recent_files.slice(0, 3).map((f) => shortPath(f)).join(", ");
-      const filesStr = files ? ` (${files})` : "";
-      const announce = s.last_announce
-        ? `: ${previewOf(s.last_announce.summary, 160)} [${formatAge(s.last_announce.age_s)}]`
-        : "";
       const marker = s.cc_loaded === false ? " [no cc]" : "";
-      lines.push(`- ${s.session} @ ${shortPath(s.cwd)}${marker}${filesStr}${announce}`);
+      // v3.4 intent line: prefer the synthesized peer summary + freshest age.
+      // Falls back to the v3.3 cwd-only line for native-only peers, since
+      // they have no cc-side activity to summarize.
+      if (s.cc_loaded !== false && s.summary) {
+        // pick freshest age: announce age if announce drove the summary, else edit age
+        const driverAge =
+          s.last_announce_age_s != null && s.last_announce_age_s < 30 * 60
+            ? s.last_announce_age_s
+            : s.last_edit_age_s ?? null;
+        const ageStr = driverAge != null ? ` (${formatAge(driverAge)} ago)` : "";
+        const branchStr = s.branch ? ` ${s.branch}` : "";
+        lines.push(`- ${s.session}${branchStr} · ${previewOf(s.summary, 100)}${ageStr}`);
+      } else {
+        lines.push(`- ${s.session} @ ${shortPath(s.cwd)}${marker}`);
+      }
     }
   }
 

--- a/plugins/cc/package.json
+++ b/plugins/cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": true,
   "type": "module",
   "bin": "./server.ts",

--- a/plugins/cc/server.ts
+++ b/plugins/cc/server.ts
@@ -451,6 +451,10 @@ type LiveSessionRow = {
   // file exists). The install-trial UX needs both visible.
   cc_loaded: boolean;
   pid: number | null;
+  // v3.4: branch surfaces in the enriched digest "intent summary" line.
+  // Populated for cc-loaded peers from the sessions row; null for native-
+  // only peers (no cc-side resolver fired in their terminal yet).
+  branch: string | null;
 };
 
 type NativeSession = {
@@ -535,7 +539,7 @@ function liveSessions(): LiveSessionRow[] {
       return (
         db
           .prepare(
-            `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root, pid
+            `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root, pid, branch
              FROM sessions
              WHERE ended_at_ms IS NULL AND last_seen_at_ms > ?
              ORDER BY last_seen_at_ms DESC`,
@@ -548,7 +552,7 @@ function liveSessions(): LiveSessionRow[] {
     // Cross-reference native sessions with cc table by session_id.
     const ccRows = db
       .prepare(
-        `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root, pid
+        `SELECT id, name, cwd, role, last_seen_at_ms, started_at_ms, project_root, pid, branch
          FROM sessions
          WHERE ended_at_ms IS NULL`,
       )
@@ -569,7 +573,9 @@ function liveSessions(): LiveSessionRow[] {
       }
       // Native-only peer (cc plugin not wired in that terminal yet).
       // Synthesize a row from native data; derive project_root via cached
-      // git lookup so scope filtering still works.
+      // git lookup so scope filtering still works. branch is null since
+      // we don't fork another git invocation just to get it; the synthesized
+      // peer line in renderDigest handles branch=null gracefully.
       return {
         id: n.sessionId,
         name: "",
@@ -580,6 +586,7 @@ function liveSessions(): LiveSessionRow[] {
         project_root: projectRootForCwd(n.cwd),
         cc_loaded: false,
         pid: n.pid,
+        branch: null,
       };
     });
   });
@@ -631,6 +638,34 @@ function lastAnnounceFor(sid: string): { summary: string; age_s: number } | null
   const age_s = Math.max(0, Math.floor((now() - row.created_at_ms) / 1000));
   if (age_s > ANNOUNCE_WINDOW_MS / 1000) return null;
   return { summary: row.summary, age_s };
+}
+
+// v3.4: most-recent edit by a peer (path + age). Used to synthesize an
+// "intent" line for the peer in the digest when no fresh announcement is
+// available. Tight 200ms TTL like the rest of the read path.
+function lastEditFor(sid: string): { path: string; age_s: number } | null {
+  const row = db
+    .prepare(
+      `SELECT path, touched_at_ms FROM recent_files
+       WHERE session_id = ?
+       ORDER BY touched_at_ms DESC LIMIT 1`,
+    )
+    .get(sid) as { path: string; touched_at_ms: number } | undefined;
+  if (!row) return null;
+  const age_s = Math.max(0, Math.floor((now() - row.touched_at_ms) / 1000));
+  return { path: row.path, age_s };
+}
+
+// v3.4: synthesize a one-line intent string for a peer.
+// Priority: fresh announcement (<30 min) > most recent edit basename > "(idle)".
+// The age is encoded into render output, not the summary string itself.
+function synthesizePeerSummary(
+  lastAnnounce: { summary: string; age_s: number } | null,
+  lastEdit: { path: string; age_s: number } | null,
+): string {
+  if (lastAnnounce && lastAnnounce.age_s < 30 * 60) return lastAnnounce.summary;
+  if (lastEdit) return path.basename(lastEdit.path);
+  return "(idle)";
 }
 
 // Topics dropped from the v3 user surface; subscriptionsFor is retained for
@@ -802,16 +837,26 @@ function computeDigest(opts: { since_ms?: number | null; scope?: "project" | "gl
   // ('name' column is retained but no longer auto-populated; if a future
   // rename verb writes to it, prefer the user-set name when present.)
   // v3.3: cc_loaded propagates into the rendered digest so the "no cc"
-  // marker fires on native-only peers (their recent_files are empty and
-  // last_announce is null because the cc plugin never wrote any).
-  const sessionDigests = peers.map((p) => ({
-    session: p.name || `${p.id.slice(0, 8)} @ ${path.basename(p.cwd)}`,
-    cwd: p.cwd,
-    role: p.role,
-    recent_files: p.cc_loaded ? recentFilesFor(p.id) : [],
-    last_announce: p.cc_loaded ? lastAnnounceFor(p.id) : null,
-    cc_loaded: p.cc_loaded,
-  }));
+  // marker fires on native-only peers.
+  // v3.4: each peer carries an enriched intent summary (branch + summary +
+  // last_edit_age_s + last_announce_age_s) so the rendered roster line goes
+  // from "abcd1234 @ repo" → "abcd1234 main · auth.ts (3m ago)".
+  const sessionDigests = peers.map((p) => {
+    const lastAnnounce = p.cc_loaded ? lastAnnounceFor(p.id) : null;
+    const lastEdit = p.cc_loaded ? lastEditFor(p.id) : null;
+    return {
+      session: p.name || `${p.id.slice(0, 8)} @ ${path.basename(p.cwd)}`,
+      cwd: p.cwd,
+      role: p.role,
+      recent_files: p.cc_loaded ? recentFilesFor(p.id) : [],
+      last_announce: lastAnnounce,
+      cc_loaded: p.cc_loaded,
+      branch: p.branch,
+      last_announce_age_s: lastAnnounce?.age_s ?? null,
+      last_edit_age_s: lastEdit?.age_s ?? null,
+      summary: p.cc_loaded ? synthesizePeerSummary(lastAnnounce, lastEdit) : null,
+    };
+  });
 
   // file_overlap_alerts: v3 redesign. The v2 design used a 10-minute time
   // window: "you both touched this file in the last 10 min." That's noisy
@@ -932,6 +977,143 @@ function computeDigest(opts: { since_ms?: number | null; scope?: "project" | "gl
     questions_awaiting_me: questionsAwaitingMe,
     my_open_questions: myOpenQuestions,
   };
+}
+
+// --- digest delta (wave B, piggyback) -------------------------------------
+//
+// Lightweight "what has changed for me since I last looked" probe. Returned
+// alongside the action-specific data on sessions/send/announce so any cc
+// call surfaces the delta without forcing an explicit check. Once a delta
+// has been observed, last_checked_at_ms advances so subsequent calls don't
+// re-show the same events.
+//
+// "Piggyback": no FSWatcher, no relay file, no new hook. The trade-off is
+// that a delta only fires on the caller's NEXT cc call, not in real time.
+// Acceptable for v1; can promote to FSWatcher relay later if usage warrants.
+//
+// Returns null when nothing has changed (so we omit the field rather than
+// emit empty arrays). Excludes self from every list.
+
+type DigestDelta = {
+  since_ms: number;
+  now_ms: number;
+  new_announcements: Array<{
+    id: string;
+    from: string;
+    summary: string;
+    age_s: number;
+  }>;
+  edited_files: Array<{
+    peer: string;
+    path: string;
+    age_s: number;
+  }>;
+  peer_joins: Array<{ id: string; cwd: string }>;
+  peer_leaves: Array<{ id: string; cwd: string }>;
+};
+
+const DIGEST_DELTA_LIMIT = 10;
+
+function computeDigestDelta(): DigestDelta | null {
+  if (!MY_SESSION_ID) return null;
+  const row = db
+    .prepare(`SELECT last_checked_at_ms FROM sessions WHERE id = ?`)
+    .get(MY_SESSION_ID) as { last_checked_at_ms: number | null } | undefined;
+  // No baseline yet (first call ever) — skip; the next call sets the baseline.
+  if (!row || row.last_checked_at_ms == null) return null;
+  const since = row.last_checked_at_ms;
+  const nowMs = now();
+
+  const announcements = db
+    .prepare(
+      `SELECT id, session_id, summary, created_at_ms
+       FROM announcements
+       WHERE created_at_ms > ? AND session_id != ?
+       ORDER BY created_at_ms DESC LIMIT ?`,
+    )
+    .all(since, MY_SESSION_ID, DIGEST_DELTA_LIMIT) as Array<{
+    id: string;
+    session_id: string;
+    summary: string;
+    created_at_ms: number;
+  }>;
+
+  const edits = db
+    .prepare(
+      `SELECT session_id, path, touched_at_ms
+       FROM recent_files
+       WHERE touched_at_ms > ? AND session_id != ?
+       ORDER BY touched_at_ms DESC LIMIT ?`,
+    )
+    .all(since, MY_SESSION_ID, DIGEST_DELTA_LIMIT) as Array<{
+    session_id: string;
+    path: string;
+    touched_at_ms: number;
+  }>;
+
+  const joins = db
+    .prepare(
+      `SELECT id, cwd FROM sessions
+       WHERE started_at_ms > ? AND id != ? AND ended_at_ms IS NULL
+       ORDER BY started_at_ms DESC LIMIT ?`,
+    )
+    .all(since, MY_SESSION_ID, DIGEST_DELTA_LIMIT) as Array<{
+    id: string;
+    cwd: string;
+  }>;
+
+  const leaves = db
+    .prepare(
+      `SELECT id, cwd FROM sessions
+       WHERE ended_at_ms IS NOT NULL AND ended_at_ms > ? AND id != ?
+       ORDER BY ended_at_ms DESC LIMIT ?`,
+    )
+    .all(since, MY_SESSION_ID, DIGEST_DELTA_LIMIT) as Array<{
+    id: string;
+    cwd: string;
+  }>;
+
+  if (
+    announcements.length === 0 &&
+    edits.length === 0 &&
+    joins.length === 0 &&
+    leaves.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    since_ms: since,
+    now_ms: nowMs,
+    new_announcements: announcements.map((a) => ({
+      id: a.id,
+      from: a.session_id.slice(0, 8),
+      summary: a.summary,
+      age_s: Math.max(0, Math.floor((nowMs - a.created_at_ms) / 1000)),
+    })),
+    edited_files: edits.map((e) => ({
+      peer: e.session_id.slice(0, 8),
+      path: e.path,
+      age_s: Math.max(0, Math.floor((nowMs - e.touched_at_ms) / 1000)),
+    })),
+    peer_joins: joins.map((p) => ({ id: p.id.slice(0, 8), cwd: p.cwd })),
+    peer_leaves: leaves.map((p) => ({ id: p.id.slice(0, 8), cwd: p.cwd })),
+  };
+}
+
+// "Consume" the delta: advance last_checked_at_ms so subsequent calls don't
+// re-show the same events. Called by every action handler that surfaces the
+// delta in its response; no-op if there's no MY_SESSION_ID.
+function advanceLastChecked(): void {
+  if (!MY_SESSION_ID) return;
+  try {
+    db.prepare(`UPDATE sessions SET last_checked_at_ms = ? WHERE id = ?`).run(
+      now(),
+      MY_SESSION_ID,
+    );
+  } catch {
+    // best-effort
+  }
 }
 
 // --- MCP tool definition ---
@@ -1081,6 +1263,20 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   touchHeartbeat();
 
   try {
+  // Wave B: every action call is a chance to surface a digest_delta.
+  // Compute once up front; if non-null, fold into the response payload AND
+  // advance last_checked_at_ms so the same delta isn't replayed next call.
+  const delta = computeDigestDelta();
+  const withDelta = <T extends Record<string, unknown>>(payload: T): T & {
+    digest_delta?: DigestDelta;
+  } => {
+    if (delta) {
+      advanceLastChecked();
+      return { ...payload, digest_delta: delta };
+    }
+    return payload;
+  };
+
   // ---- sessions ----
   if (action.action === "sessions") {
     const includeSelf = action.include_self === true;
@@ -1104,7 +1300,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     const nativeOnlyCount = out.length - ccLoadedCount;
     return text(
       JSON.stringify(
-        {
+        withDelta({
           sessions: out,
           scope: action.scope ?? "project",
           summary: {
@@ -1116,7 +1312,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
                 ? "native_only peers have a Claude Code session but cc plugin isn't wired yet — they need to restart their terminal once after install."
                 : undefined,
           },
-        },
+        }),
         null,
         2,
       ),
@@ -1142,7 +1338,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     const filename = `${now()}-${MY_SESSION_ID}-${id}.msg`;
     const dir = path.join(INBOX_DIR, target.id);
     atomicWrite(dir, filename, body);
-    return text(JSON.stringify({ id, delivered_to: [target.id] }));
+    return text(JSON.stringify(withDelta({ id, delivered_to: [target.id] })));
   }
 
   // ---- announce ----
@@ -1152,7 +1348,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       `INSERT INTO announcements (id, session_id, summary, detail, topics, created_at_ms)
        VALUES (?, ?, ?, ?, NULL, ?)`,
     ).run(id, MY_SESSION_ID, action.summary, action.detail ?? null, now());
-    return text(JSON.stringify({ id }));
+    return text(JSON.stringify(withDelta({ id })));
   }
 
   // ---- check ----

--- a/plugins/cc/skills/sessions/SKILL.md
+++ b/plugins/cc/skills/sessions/SKILL.md
@@ -67,6 +67,13 @@ coordination (e.g. "I'm about to push to the same branch you're rebasing").
   message before continuing edits on a flagged file — that's the protocol.
 - **Announcements** are fire-and-forget broadcasts; peers see them in their
   next digest. No reply expected.
+- **`digest_delta` rides every cc call** (v3.3+). When the peer-visible
+  state has changed since this session's last cc call, the response from
+  `sessions` / `send` / `announce` includes a `digest_delta` block with
+  new announcements, edited files, peer joins, peer leaves. You don't
+  have to call `check` to discover this — it surfaces wherever you happen
+  to be calling cc. Once observed, the delta is consumed; the next call
+  shows only changes after that point.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Two interlocking read-side enrichments. **No new tables, no new hooks, no new external infra.** ~120 LOC net change.

### 1. Peer intent summary
Each peer carries an enriched shape: `branch`, `summary` (one-line synthesis), `last_announce_age_s`, `last_edit_age_s`.

| before | after |
|---|---|
| \`- abcd1234 @ repo\` | \`- abcd1234 main · auth.ts (3m ago)\` |

Summary priority: latest <30min announcement → most-recent-touched file basename → "(idle)".

### 2. Piggyback `digest_delta`
When `cc(action='sessions'|'send'|'announce')` runs, the response includes a `digest_delta` block:

```json
{
  "since_ms": ...,
  "now_ms": ...,
  "new_announcements": [{ "id", "from", "summary", "age_s" }],
  "edited_files":      [{ "peer", "path", "age_s" }],
  "peer_joins":        [{ "id", "cwd" }],
  "peer_leaves":       [{ "id", "cwd" }]
}
```

Once surfaced, `last_checked_at_ms` advances. The same delta won't replay on the next call. The block is omitted when nothing has changed.

**Trade-off:** delta only fires on the caller's next cc call (vs. true push). Acceptable for v1; promotable to an FSWatcher relay in a future wave if usage warrants.

The `check` action already returned delta-shaped digest text via `computeDigest`; the piggyback adds the other 3 actions so awareness travels with whatever the model is naturally calling.

## Version

3.2.0 → **3.3.0** (combining wave A.6 + wave B, both shipped in this minor)

## Test plan

- [x] `bun test tests/` — 36 pass
- [x] `bunx tsc --noEmit` — clean
- [x] End-to-end: isolated `CC_STATE_DIR`, synthetic peer announce + edit + join, `cc(action='sessions')` response includes `digest_delta` with correctly-populated `new_announcements`, `edited_files`, `peer_joins` (all age_s ≈ 1s)

## Out of scope

- Subscriptions verb (wave C)
- claim/release primitive (wave C)
- True push via FSWatcher relay (revisit if usage warrants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)