### PR TITLE
feat(cc): wave C — declarative subscriptions (file glob + peer + urgency match)

### DIFF
--- a/plugins/cc/.claude-plugin/plugin.json
+++ b/plugins/cc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Session mesh for Claude Code. Email-cc semantics: every session stays informed of what its siblings are doing, with file-overlap alerts that prevent two agents silently clobbering the same file.",
   "author": { "name": "Ani Potts", "url": "https://github.com/anipotts" },
   "repository": "https://github.com/anipotts/claude-code-tips",

--- a/plugins/cc/CHANGELOG.md
+++ b/plugins/cc/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to the cc plugin are documented here. The format follows
 
 ## [Unreleased]
 
+## [3.4.0] — 2026-05-07
+
+### Added
+- **Wave C subscriptions** — declarative match rules. Two new verbs:
+  `cc(action='subscribe', { files?, peers?, urgency_min? })` returns an
+  id; `cc(action='unsubscribe', { id })` removes. Each cc call now also
+  computes `subscription_matches` against the caller's subs and includes
+  the matching events alongside `digest_delta`. Without subs, the field
+  is omitted; with subs the model can prioritize matches without an
+  extra query.
+- **`cc_subs` table** in the schema. Idempotent CREATE; legacy v2
+  `subscriptions` (topic-based) stays dormant for back-compat.
+- **Glob matcher** — `**` for any depth, `*` for single segment, `?`
+  for single char. Path matching only (DM matching uses urgency_min).
+
+### Changed
+- `TOOL_DESCRIPTION` lists the two new verbs.
+- ACTION_NAMES bumped from 4 to 6. Schema bytes change once on `tools/list`
+  (one prompt-cache invalidation), then byte-stable.
+- `cleanupSelf()` also drops the session's `cc_subs` rows on shutdown.
+
 ## [3.3.0] — 2026-05-07
 
 ### Added
@@ -110,7 +131,8 @@ All notable changes to the cc plugin are documented here. The format follows
 ### Closed issues
 - Prior issues tracked in `BACKLOG.md` (now removed; tracked on GitHub).
 
-[Unreleased]: https://github.com/anipotts/claude-code-tips/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/anipotts/claude-code-tips/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.4.0
 [3.3.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.3.0
 [3.2.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.2.0
 [3.1.0]: https://github.com/anipotts/claude-code-tips/releases/tag/v3.1.0

--- a/plugins/cc/db/schema.sql
+++ b/plugins/cc/db/schema.sql
@@ -49,6 +49,20 @@ CREATE TABLE IF NOT EXISTS subscriptions (
 );
 CREATE INDEX IF NOT EXISTS idx_subs_topic ON subscriptions(topic);
 
+-- Wave C: declarative subscription matchers. Replaces the v2 topic surface.
+-- Each row is one match rule for a session: "show me events that touch
+-- {file_glob} AND/OR are produced by {peer_match} AND/OR meet urgency_min".
+-- The legacy `subscriptions` table above stays dormant for back-compat.
+CREATE TABLE IF NOT EXISTS cc_subs (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  file_glob TEXT,
+  peer_match TEXT,
+  urgency_min TEXT,
+  created_at_ms INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cc_subs_session ON cc_subs(session_id);
+
 CREATE TABLE IF NOT EXISTS recent_files (
   session_id TEXT NOT NULL,
   path TEXT NOT NULL,

--- a/plugins/cc/lib/action.ts
+++ b/plugins/cc/lib/action.ts
@@ -83,6 +83,41 @@ export const ActionSchema = z.discriminatedUnion("action", [
       scope: scopeSchema,
     })
     .strict(),
+
+  // Wave C: declarative subscriptions. Replaces v2 topics.
+  z
+    .object({
+      action: z.literal("subscribe"),
+      files: z
+        .string()
+        .optional()
+        .describe(
+          "file path glob (e.g. 'src/auth/**'); matches edited file paths from digest_delta. ** = any depth, * = single segment.",
+        ),
+      peers: z
+        .string()
+        .optional()
+        .describe(
+          "peer match: 'any', short id (8 hex), or full session id; restricts the subscription to this peer's activity",
+        ),
+      urgency_min: z
+        .enum(["low", "normal", "urgent", "question"])
+        .optional()
+        .describe(
+          "minimum urgency for DM matches; ignored for file/announcement events",
+        ),
+    })
+    .strict(),
+
+  z
+    .object({
+      action: z.literal("unsubscribe"),
+      id: z
+        .string()
+        .min(1)
+        .describe("subscription id from cc(action='subscribe') response"),
+    })
+    .strict(),
 ]);
 
 export type Action = z.infer<typeof ActionSchema>;
@@ -93,6 +128,8 @@ export const ACTION_NAMES: readonly ActionName[] = [
   "send",
   "announce",
   "check",
+  "subscribe",
+  "unsubscribe",
 ] as const;
 
 // --- MCP tool description ---------------------------------------------------
@@ -106,8 +143,9 @@ export const ACTION_NAMES: readonly ActionName[] = [
 // service codes.
 export const TOOL_DESCRIPTION =
   "cc — Claude Code session mesh, peer messaging, multi-agent coordination on this machine. " +
-  "Actions: sessions (list peers), send (DM peer), announce (broadcast status), check (pull digest). " +
-  "DM arrival is push-delivered via the channel; polling check is rarely needed. " +
+  "Actions: sessions (list peers), send (DM peer), announce (broadcast status), check (pull digest), " +
+  "subscribe / unsubscribe (declarative match rules surfaced as subscription_matches). " +
+  "DM arrival push-delivered via the channel; digest_delta piggybacks every cc call. " +
   "Default scope is the current git project_root.";
 
 // --- pre-built JSON Schema (cached at module load) --------------------------

--- a/plugins/cc/package.json
+++ b/plugins/cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "type": "module",
   "bin": "./server.ts",

--- a/plugins/cc/server.ts
+++ b/plugins/cc/server.ts
@@ -366,6 +366,7 @@ function cleanupSelf(): void {
       MY_SESSION_ID,
     );
     db.prepare(`DELETE FROM subscriptions WHERE session_id = ?`).run(MY_SESSION_ID);
+    db.prepare(`DELETE FROM cc_subs WHERE session_id = ?`).run(MY_SESSION_ID);
     db.prepare(`DELETE FROM recent_files WHERE session_id = ?`).run(MY_SESSION_ID);
   } catch {
     // db may already be closing during shutdown; best-effort
@@ -1116,6 +1117,153 @@ function advanceLastChecked(): void {
   }
 }
 
+// --- subscription matcher (wave C) ----------------------------------------
+//
+// Subscriptions are declarative match rules that ride on top of the digest_delta.
+// Computed alongside the delta on every cc call: each of the caller's subs is
+// tested against the delta's events and the inbox's unread DMs. Matches are
+// surfaced in the response so the model can prioritize without re-querying.
+//
+// Match semantics: a sub matches an event when ALL of its non-null filters
+// pass.
+//   - file_glob:   restrict to events whose path matches the glob
+//   - peer_match:  restrict to events from this peer (short id, full id, or "any")
+//   - urgency_min: only meaningful for DM events; ignored for files / announces
+//
+// A sub with all three null is a no-op (matches nothing) by design — the
+// schema in lib/action.ts steers callers to provide at least one filter.
+
+type SubRow = {
+  id: string;
+  file_glob: string | null;
+  peer_match: string | null;
+  urgency_min: string | null;
+};
+
+type SubMatchEvent =
+  | { kind: "edited_file"; peer: string; path: string; age_s: number }
+  | { kind: "announcement"; peer: string; summary: string; age_s: number }
+  | { kind: "dm"; from: string; subject: string; urgency: string; age_s: number };
+
+type SubscriptionMatch = {
+  sub_id: string;
+  events: SubMatchEvent[];
+};
+
+const URGENCY_RANK: Record<string, number> = {
+  low: 0,
+  normal: 1,
+  question: 2,
+  urgent: 3,
+};
+
+// Convert a path glob to a RegExp.
+//   `**` matches any number of path segments (including zero).
+//   `*`  matches any chars except `/`.
+//   `?`  matches a single char except `/`.
+//   Other regex metachars are escaped.
+function globToRegex(glob: string): RegExp {
+  const DOUBLE = " ";
+  const escaped = glob
+    .replace(/[.+^$()[\]{}|\\]/g, "\\$&")
+    .replace(/\*\*/g, DOUBLE)
+    .replace(/\*/g, "[^/]*")
+    .split(DOUBLE)
+    .join(".*")
+    .replace(/\?/g, "[^/]");
+  return new RegExp(`^${escaped}$`);
+}
+
+function peerMatches(filter: string | null, peerId: string): boolean {
+  if (!filter || filter === "any") return true;
+  // Compare by prefix to support short ids (8 hex) or full ids.
+  return peerId === filter || peerId.startsWith(filter) || filter.startsWith(peerId);
+}
+
+function computeSubscriptionMatches(
+  delta: DigestDelta | null,
+): SubscriptionMatch[] {
+  if (!MY_SESSION_ID) return [];
+  const subs = db
+    .prepare(
+      `SELECT id, file_glob, peer_match, urgency_min FROM cc_subs WHERE session_id = ?`,
+    )
+    .all(MY_SESSION_ID) as SubRow[];
+  if (subs.length === 0) return [];
+
+  // Inbox DMs: scan unread .msg files for urgency-matching subs. We only
+  // need one pass even if multiple subs match.
+  type InboxEntry = { fromSid: string; subject: string; urgency: string; age_s: number };
+  const inbox: InboxEntry[] = [];
+  if (subs.some((s) => s.urgency_min)) {
+    try {
+      const myInbox = path.join(INBOX_DIR, MY_SESSION_ID);
+      const nowMs = now();
+      for (const f of fs.readdirSync(myInbox)) {
+        if (!f.endsWith(".msg") || f.startsWith(".")) continue;
+        try {
+          const m = parseMsgFile(fs.readFileSync(path.join(myInbox, f), "utf-8"));
+          inbox.push({
+            fromSid: m.fromSid || "",
+            subject: m.subject,
+            urgency: m.urgency,
+            age_s: Math.max(0, Math.floor((nowMs - m.created_at_ms) / 1000)),
+          });
+        } catch {
+          // skip
+        }
+      }
+    } catch {
+      // no inbox dir
+    }
+  }
+
+  const matches: SubscriptionMatch[] = [];
+  for (const sub of subs) {
+    const events: SubMatchEvent[] = [];
+    const re = sub.file_glob ? globToRegex(sub.file_glob) : null;
+
+    if (delta) {
+      // file events
+      for (const ef of delta.edited_files) {
+        if (re && !re.test(ef.path)) continue;
+        if (!peerMatches(sub.peer_match, ef.peer)) continue;
+        events.push({ kind: "edited_file", peer: ef.peer, path: ef.path, age_s: ef.age_s });
+      }
+      // announcement events: only when no file_glob is set (announcements
+      // don't have paths, so a file_glob filter excludes them by intent).
+      if (!sub.file_glob) {
+        for (const ann of delta.new_announcements) {
+          if (!peerMatches(sub.peer_match, ann.from)) continue;
+          events.push({ kind: "announcement", peer: ann.from, summary: ann.summary, age_s: ann.age_s });
+        }
+      }
+    }
+
+    // DM events: orthogonal to delta. Filter by urgency_min and peer_match.
+    if (sub.urgency_min) {
+      const min = URGENCY_RANK[sub.urgency_min] ?? 0;
+      for (const dm of inbox) {
+        const dmShort = dm.fromSid.slice(0, 8);
+        if (!peerMatches(sub.peer_match, dmShort)) continue;
+        if ((URGENCY_RANK[dm.urgency] ?? 0) < min) continue;
+        events.push({
+          kind: "dm",
+          from: dmShort,
+          subject: dm.subject,
+          urgency: dm.urgency,
+          age_s: dm.age_s,
+        });
+      }
+    }
+
+    if (events.length > 0) {
+      matches.push({ sub_id: sub.id, events });
+    }
+  }
+  return matches;
+}
+
 // --- MCP tool definition ---
 //
 // One tool, four actions. Verb surface lives in lib/action.ts; this file is
@@ -1266,15 +1414,25 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   // Wave B: every action call is a chance to surface a digest_delta.
   // Compute once up front; if non-null, fold into the response payload AND
   // advance last_checked_at_ms so the same delta isn't replayed next call.
+  // Wave C: also surface subscription_matches if the caller has any subs.
   const delta = computeDigestDelta();
+  const subMatches = computeSubscriptionMatches(delta);
   const withDelta = <T extends Record<string, unknown>>(payload: T): T & {
     digest_delta?: DigestDelta;
+    subscription_matches?: SubscriptionMatch[];
   } => {
+    let out: typeof payload & {
+      digest_delta?: DigestDelta;
+      subscription_matches?: SubscriptionMatch[];
+    } = payload;
     if (delta) {
       advanceLastChecked();
-      return { ...payload, digest_delta: delta };
+      out = { ...out, digest_delta: delta };
     }
-    return payload;
+    if (subMatches.length > 0) {
+      out = { ...out, subscription_matches: subMatches };
+    }
+    return out;
   };
 
   // ---- sessions ----
@@ -1349,6 +1507,49 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
        VALUES (?, ?, ?, ?, NULL, ?)`,
     ).run(id, MY_SESSION_ID, action.summary, action.detail ?? null, now());
     return text(JSON.stringify(withDelta({ id })));
+  }
+
+  // ---- subscribe (wave C) ----
+  if (action.action === "subscribe") {
+    if (!action.files && !action.peers && !action.urgency_min) {
+      return errorText(
+        "cc.subscribe: provide at least one of {files, peers, urgency_min}; an empty match is a no-op.",
+      );
+    }
+    const id = newId("s");
+    db.prepare(
+      `INSERT INTO cc_subs (id, session_id, file_glob, peer_match, urgency_min, created_at_ms)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      id,
+      MY_SESSION_ID,
+      action.files ?? null,
+      action.peers ?? null,
+      action.urgency_min ?? null,
+      now(),
+    );
+    return text(
+      JSON.stringify(
+        withDelta({
+          id,
+          subscription: {
+            files: action.files ?? null,
+            peers: action.peers ?? null,
+            urgency_min: action.urgency_min ?? null,
+          },
+        }),
+      ),
+    );
+  }
+
+  // ---- unsubscribe (wave C) ----
+  if (action.action === "unsubscribe") {
+    const res = db
+      .prepare(`DELETE FROM cc_subs WHERE id = ? AND session_id = ?`)
+      .run(action.id, MY_SESSION_ID);
+    return text(
+      JSON.stringify(withDelta({ removed: res.changes > 0, id: action.id })),
+    );
   }
 
   // ---- check ----

--- a/plugins/cc/skills/sessions/SKILL.md
+++ b/plugins/cc/skills/sessions/SKILL.md
@@ -45,6 +45,8 @@ If `mcp__cc__cc` isn't in your tool list:
 | "tell <peer> X", "ask <peer> Y", "ping merizo" | `send` |
 | "let peers know I'm refactoring auth", "broadcast: tests are red" | `announce` |
 | "what's happening on this machine right now?", explicit poll | `check` |
+| "alert me when anyone touches src/auth/**" | `subscribe` |
+| "stop watching for that, here's the id" | `unsubscribe` |
 
 ## Targeting peers (`send`)
 
@@ -58,6 +60,21 @@ The `to` field accepts:
 Use `urgency='question'` only when you actually need a reply; otherwise
 `'normal'` (default) is right. `'urgent'` is reserved for blocking
 coordination (e.g. "I'm about to push to the same branch you're rebasing").
+
+## Subscriptions (`subscribe` / `unsubscribe`)
+
+Declarative match rules surfaced as `subscription_matches` alongside
+`digest_delta` on every cc call. Provide at least one of:
+
+- `files`: glob like `"src/auth/**"` or `"**/test_*.py"`. `**` = any depth,
+  `*` = single segment, `?` = single char.
+- `peers`: `"any"`, an 8-hex short id, or a full session id. Restricts the
+  sub to that peer's activity.
+- `urgency_min`: `"low" | "normal" | "question" | "urgent"`. Only meaningful
+  for DM matches; ignored for file/announce events.
+
+Subscriptions are advisory — they don't filter what `digest_delta` shows.
+The model still sees everything; matches highlight what to prioritize.
 
 ## Awareness loop
 

--- a/plugins/cc/tests/action.test.ts
+++ b/plugins/cc/tests/action.test.ts
@@ -45,11 +45,32 @@ describe("ActionSchema (zod source of truth)", () => {
     ).toBe(true);
   });
 
-  it("rejects dropped verbs (subscribe / unsubscribe / ask / answer / cleanup)", () => {
-    for (const a of ["subscribe", "unsubscribe", "ask", "answer", "cleanup"]) {
+  it("rejects truly-dropped verbs (ask / answer / cleanup)", () => {
+    for (const a of ["ask", "answer", "cleanup"]) {
       const r = ActionSchema.safeParse({ action: a });
       expect(r.success).toBe(false);
     }
+  });
+
+  it("accepts wave C subscribe / unsubscribe", () => {
+    expect(ActionSchema.safeParse({ action: "subscribe" }).success).toBe(true);
+    expect(
+      ActionSchema.safeParse({ action: "subscribe", files: "src/**" }).success,
+    ).toBe(true);
+    expect(
+      ActionSchema.safeParse({
+        action: "subscribe",
+        peers: "any",
+        urgency_min: "question",
+      }).success,
+    ).toBe(true);
+    expect(
+      ActionSchema.safeParse({ action: "unsubscribe", id: "s_xxx" }).success,
+    ).toBe(true);
+    expect(ActionSchema.safeParse({ action: "unsubscribe" }).success).toBe(false);
+    expect(
+      ActionSchema.safeParse({ action: "unsubscribe", id: "" }).success,
+    ).toBe(false);
   });
 
   it("rejects send without required fields", () => {
@@ -102,14 +123,21 @@ describe("ActionSchema (zod source of truth)", () => {
   });
 
   it("ACTION_NAMES matches schema branches", () => {
-    expect(ACTION_NAMES).toEqual(["sessions", "send", "announce", "check"]);
+    expect(ACTION_NAMES).toEqual([
+      "sessions",
+      "send",
+      "announce",
+      "check",
+      "subscribe",
+      "unsubscribe",
+    ]);
   });
 });
 
 describe("ACTION_JSON_SCHEMA (model-facing)", () => {
   it("is a oneOf of one branch per action", () => {
     expect(ACTION_JSON_SCHEMA.oneOf).toBeDefined();
-    expect((ACTION_JSON_SCHEMA.oneOf as unknown[]).length).toBe(4);
+    expect((ACTION_JSON_SCHEMA.oneOf as unknown[]).length).toBe(ACTION_NAMES.length);
   });
 
   it("does not include anyOf (post-processed to oneOf)", () => {


### PR DESCRIPTION
## Summary

Two new verbs (`subscribe` / `unsubscribe`) replace the dropped v3 topic surface with a fully declarative match primitive. Rides on the wave B `digest_delta` path — new rule store (`cc_subs` table), no new event store.

## Verbs

```ts
cc(action='subscribe', { files?, peers?, urgency_min? }) → { id, subscription }
cc(action='unsubscribe', { id }) → { removed }
```

### Match semantics (all non-null filters must pass)

| filter | what |
|---|---|
| `files` | glob — `**` = any depth, `*` = single segment, `?` = single char |
| `peers` | `"any"`, 8-hex short id, or full session id |
| `urgency_min` | `low \| normal \| question \| urgent` (DM-only) |

### Response shape

Every cc call now emits `subscription_matches` alongside `digest_delta` (when matches exist). Matches don't filter the digest — the model still sees full activity; matches just highlight what to prioritize.

```json
{
  ...,
  "digest_delta": { "edited_files": [...], "new_announcements": [...], ... },
  "subscription_matches": [
    {
      "sub_id": "s_5af0a49ff4",
      "events": [
        { "kind": "edited_file", "peer": "abcd1234", "path": "src/auth/login.ts", "age_s": 0 }
      ]
    }
  ]
}
```

## Schema

```sql
CREATE TABLE IF NOT EXISTS cc_subs (
  id TEXT PRIMARY KEY,
  session_id TEXT NOT NULL,
  file_glob TEXT,
  peer_match TEXT,
  urgency_min TEXT,
  created_at_ms INTEGER NOT NULL
);
```

Idempotent CREATE. The legacy v2 `subscriptions` table (topic-based) stays dormant for back-compat. `cleanupSelf()` also drops the session's `cc_subs` rows on shutdown.

## Test plan

- [x] `bun test tests/` — 37 pass (new tests cover subscribe/unsubscribe parse + ACTION_NAMES count)
- [x] `bunx tsc --noEmit` — clean
- [x] End-to-end: subscribe to `src/auth/**`, peer edits `src/auth/login.ts` + `src/dashboard/index.ts`. `cc(action='sessions')` returns `digest_delta` with both edits plus `subscription_matches` with only `login.ts`. Match logic correctly filters by glob.

## Version

3.3.0 → **3.4.0**. ACTION_NAMES 4 → 6. Schema bytes change once on `tools/list` (one prompt-cache invalidation), then byte-stable.

## Out of scope (next: wave C claim/release, requires explicit greenlight)

- claim/release with PreToolUse hook integration (~250 LOC, larger surface)
- True push promotion of digest_delta from piggyback to FSWatcher relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)