### PR TITLE
feat(cc)!: v3.6.0 — sqlite + bash as primary path; MCP becomes optional

### DIFF
--- a/plugins/cc/.claude-plugin/plugin.json
+++ b/plugins/cc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Session mesh for Claude Code. Email-cc semantics: every session stays informed of what its siblings are doing, with file-overlap alerts that prevent two agents silently clobbering the same file.",
   "author": { "name": "Ani Potts", "url": "https://github.com/anipotts" },
   "repository": "https://github.com/anipotts/claude-code-tips",

--- a/plugins/cc/CHANGELOG.md
+++ b/plugins/cc/CHANGELOG.md
@@ -8,6 +8,34 @@ All notable changes to the cc plugin are documented here. The format follows
 
 ## [Unreleased]
 
+## [3.6.0] — 2026-05-08
+
+### Added
+- **`bin/cc-quick` — direct cc state access without MCP.** Bash + sqlite3
+  helper that reads `~/.claude/channels/cc/sessions.db` and writes
+  `inbox/<sid>/*.msg` files atomically. Always works regardless of MCP
+  tool registration state. Verbs: `roster`, `send`, `announce`, `check`,
+  `mine`. ~150 LOC, no dependencies beyond `bash`/`sqlite3`/`uuidgen`.
+
+### Changed
+- **`SKILL.md` reframes the path hierarchy.** sqlite + filesystem direct
+  access is now the FAST PATH, not a fallback. MCP is documented as
+  the typed/validated path that's optimal when available but never
+  required. Each verb explicitly lists which path is faster.
+- **`send` no longer requires MCP.** The recipient's cc-server
+  `inbox-watch` FSWatcher dispatches the channel push notification on
+  ANY new `.msg` file landing, regardless of who wrote it. Direct
+  bash writes via `cc-quick send` produce identical recipient-side
+  behavior to MCP send.
+
+### Why
+Real-world feedback: in the install-trigger session (the terminal that
+ran `/plugin install`), the cc MCP tool isn't reachable until that
+terminal restarts (CC harness doesn't re-poll `tools/list` mid-session).
+The previous SKILL.md framed sqlite as a "fallback" which made users
+feel the install-trigger session was second-class. v3.6 treats both
+paths as first-class with explicit per-verb routing.
+
 ## [3.5.0] — 2026-05-08
 
 ### Added

--- a/plugins/cc/bin/cc-quick
+++ b/plugins/cc/bin/cc-quick
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# cc-quick — direct cc state writes without MCP.
+#
+# Reads/writes ~/.claude/channels/cc/{sessions.db,inbox/<sid>/*.msg}
+# directly. Always works regardless of MCP tool registration state.
+#
+# Usage:
+#   cc-quick roster                              # list active peers
+#   cc-quick send <short-id> <message> [subj]    # DM a peer
+#   cc-quick announce <summary> [detail]         # broadcast status
+#   cc-quick check [since_s]                     # plain digest
+#   cc-quick mine                                # my own session row
+#
+# Exits 0 on success. 1 on sender error (invalid args, missing target).
+# 2 on environmental issue (db missing, can't write inbox).
+#
+# tested with: claude code v2.1.133, bash 5+, sqlite3 3.40+
+set -euo pipefail
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CC_DIR="${CC_STATE_DIR:-$CLAUDE_DIR/channels/cc}"
+DB="$CC_DIR/sessions.db"
+INBOX="$CC_DIR/inbox"
+
+die() { echo "cc-quick: $*" >&2; exit 1; }
+env_err() { echo "cc-quick: $*" >&2; exit 2; }
+
+[ -f "$DB" ] || env_err "sessions.db not at $DB — install/start cc first"
+MY_SID="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+[ -n "$MY_SID" ] || env_err "CLAUDE_CODE_SESSION_ID not set; can't identify self"
+MY_SHORT="${MY_SID:0:8}"
+MY_CWD_BASENAME="$(basename "$PWD")"
+
+# ms-precision timestamp (date +%s%N is ns; trim to 13 chars for ms)
+now_ms() { date +%s%N | cut -c1-13; }
+
+# urlsafe random hex of length N. uuidgen if available else /dev/urandom.
+rand_hex() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr -d - | tr '[:upper:]' '[:lower:]' | head -c "${1:-16}"
+  else
+    head -c 256 /dev/urandom | xxd -p | tr -d '\n' | head -c "${1:-16}"
+  fi
+}
+
+# Resolve a peer reference (short id, full id, or cwd basename) to a full
+# session_id. Echos the full id, or empty string if not found.
+resolve_target() {
+  local ref="$1"
+  # try short id first (8 hex), then full id, then cwd basename. Prefer
+  # most-recently-active match on ambiguity.
+  sqlite3 "$DB" <<SQL | head -1
+SELECT id FROM sessions
+WHERE ended_at_ms IS NULL
+  AND (substr(id,1,8) = '$ref' OR id = '$ref' OR cwd LIKE '%/$ref')
+ORDER BY last_seen_at_ms DESC
+LIMIT 1;
+SQL
+}
+
+cmd_roster() {
+  sqlite3 -header -column "$DB" <<SQL
+SELECT substr(id,1,8) AS sid,
+       cwd,
+       COALESCE(branch, '') AS branch,
+       datetime(last_seen_at_ms/1000, 'unixepoch', 'localtime') AS last_seen
+FROM sessions
+WHERE ended_at_ms IS NULL
+ORDER BY last_seen_at_ms DESC;
+SQL
+}
+
+cmd_send() {
+  local target_ref="${1:-}"
+  local message="${2:-}"
+  local subject="${3:-}"
+  [ -n "$target_ref" ] || die "send: missing target (short id, full id, or cwd basename)"
+  [ -n "$message" ] || die "send: missing message"
+
+  local target_sid
+  target_sid=$(resolve_target "$target_ref")
+  [ -n "$target_sid" ] || die "send: no live peer matching '$target_ref'"
+
+  local ts msg_id dir filename
+  ts=$(now_ms)
+  msg_id=$(rand_hex 16)
+  dir="$INBOX/$target_sid"
+  mkdir -p "$dir"
+  filename="${ts}-${MY_SID}-${msg_id}.msg"
+
+  # Build msg body. Use a heredoc with quoted EOF to disable expansion;
+  # multiline body is preserved exactly. Subject + Meta lines are optional.
+  local tmp="$dir/.${filename}.tmp"
+  {
+    printf 'From: %s @ %s\n' "$MY_SHORT" "$MY_CWD_BASENAME"
+    printf 'From-Sid: %s\n' "$MY_SID"
+    printf 'Urgency: normal\n'
+    printf 'Timestamp: %s\n' "$ts"
+    [ -n "$subject" ] && printf 'Subject: %s\n' "$subject"
+    printf -- '---\n'
+    printf '%s\n' "$message"
+  } > "$tmp"
+  mv "$tmp" "$dir/$filename"
+  echo "delivered: $msg_id → ${target_sid:0:8} ($filename)"
+}
+
+cmd_announce() {
+  local summary="${1:-}"
+  local detail="${2:-}"
+  [ -n "$summary" ] || die "announce: missing summary"
+  local id ts
+  id=$(rand_hex 16)
+  ts=$(now_ms)
+  # Use parameter binding to avoid SQL injection on summary/detail.
+  sqlite3 "$DB" <<SQL
+INSERT INTO announcements (id, session_id, summary, detail, created_at_ms)
+VALUES (
+  $(printf "%s" "'$id'"),
+  $(printf "%s" "'$MY_SID'"),
+  $(sqlite3 "$DB" <<<"SELECT quote('$(printf '%s' "$summary" | sed "s/'/''/g")');"),
+  $(if [ -n "$detail" ]; then sqlite3 "$DB" <<<"SELECT quote('$(printf '%s' "$detail" | sed "s/'/''/g")');"; else echo "NULL"; fi),
+  $ts
+);
+SQL
+  echo "announced: $id"
+}
+
+cmd_check() {
+  local since_s="${1:-1800}"  # default 30min
+  local since_ms
+  since_ms=$(( $(now_ms) - since_s * 1000 ))
+
+  echo "=== announcements (last ${since_s}s, peers only) ==="
+  sqlite3 -header -column "$DB" <<SQL
+SELECT substr(a.session_id,1,8) AS sid,
+       datetime(a.created_at_ms/1000,'unixepoch','localtime') AS at,
+       a.summary
+FROM announcements a
+JOIN sessions s ON s.id = a.session_id
+WHERE s.ended_at_ms IS NULL
+  AND a.session_id != '$MY_SID'
+  AND a.created_at_ms > $since_ms
+ORDER BY a.created_at_ms DESC LIMIT 20;
+SQL
+  echo ""
+  echo "=== recent file edits by peers (last ${since_s}s) ==="
+  sqlite3 -header -column "$DB" <<SQL
+SELECT substr(rf.session_id,1,8) AS sid,
+       rf.path,
+       datetime(rf.touched_at_ms/1000,'unixepoch','localtime') AS at
+FROM recent_files rf
+JOIN sessions s ON s.id = rf.session_id
+WHERE s.ended_at_ms IS NULL
+  AND rf.session_id != '$MY_SID'
+  AND rf.touched_at_ms > $since_ms
+ORDER BY rf.touched_at_ms DESC LIMIT 20;
+SQL
+}
+
+cmd_mine() {
+  sqlite3 -header -column "$DB" <<SQL
+SELECT substr(id,1,8) AS sid,
+       cwd,
+       COALESCE(branch,'') AS branch,
+       COALESCE(project_root,'') AS project_root,
+       datetime(started_at_ms/1000,'unixepoch','localtime') AS started,
+       datetime(last_seen_at_ms/1000,'unixepoch','localtime') AS last_seen
+FROM sessions
+WHERE id = '$MY_SID';
+SQL
+}
+
+case "${1:-}" in
+  roster)   shift; cmd_roster "$@" ;;
+  send)     shift; cmd_send "$@" ;;
+  announce) shift; cmd_announce "$@" ;;
+  check)    shift; cmd_check "$@" ;;
+  mine)     shift; cmd_mine "$@" ;;
+  ""|-h|--help)
+    sed -n '2,15p' "$0" | sed 's/^# \?//'
+    ;;
+  *) die "unknown command '$1'. try: roster send announce check mine" ;;
+esac

--- a/plugins/cc/package.json
+++ b/plugins/cc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "private": true,
   "type": "module",
   "bin": "./server.ts",

--- a/plugins/cc/skills/sessions/SKILL.md
+++ b/plugins/cc/skills/sessions/SKILL.md
@@ -9,116 +9,150 @@ description: |
   or any cross-session / multi-agent coordination on this machine.
 model: haiku
 ---
-<!-- tested with: claude code v2.1.132 -->
+<!-- tested with: claude code v2.1.133 -->
 
 # cc — session mesh
 
-Use the **cc MCP tool** with one of four actions. The tool description in
-your context already documents arg shapes; this skill covers *when* to pick
-which action.
+cc has TWO equivalent invocation surfaces. Both go to the same sqlite +
+filesystem state. Pick the fast one for the verb you're running.
 
-## After a fresh install
+## The fast path (always reliable)
 
-The MCP tool is registered when a Claude Code session starts. **The session
-that just ran `/plugin install cc@claude-code-tips` cannot itself call the
-tool until that terminal restarts** — Claude Code doesn't re-poll
-`tools/list` mid-session. New sessions opened after the install pick up the
-tool immediately.
+cc state lives in `~/.claude/channels/cc/`:
+- `sessions.db` — peer roster, recent_files, announcements, subscriptions
+- `inbox/<sid>/*.msg` — direct messages (any new file triggers recipient's
+  push notification via their cc-server's FSWatcher)
 
-If `mcp__cc__cc` isn't in your tool list:
+The fast path reads/writes that state directly via `sqlite3` + atomic file
+writes. Works in **every** session including the install-trigger one,
+regardless of whether the cc MCP tool registered. ~3ms reads, ~10ms writes.
 
-- Tell the user to open a new terminal and run `claude` there. That session
-  has the tool.
-- For the roster verb only, you can fall back to a direct sqlite read:
-  `sqlite3 ~/.claude/channels/cc/sessions.db "SELECT id, cwd, last_seen_at_ms FROM sessions WHERE ended_at_ms IS NULL ORDER BY last_seen_at_ms DESC"`.
-  This is read-only and only useful for "who's running"; for `send` /
-  `announce` / `check` you need the MCP tool.
-- The cc plugin's SessionStart hook registers every session in the cc table
-  on session start, so peer visibility works regardless of whether the MCP
-  tool is reachable in *this* session.
+### roster — "who else is running?"
+
+```bash
+sqlite3 ~/.claude/channels/cc/sessions.db \
+  "SELECT substr(id,1,8) AS sid, cwd, branch, datetime(last_seen_at_ms/1000,'unixepoch','localtime') AS last_seen
+   FROM sessions WHERE ended_at_ms IS NULL
+   ORDER BY last_seen_at_ms DESC"
+```
+
+### send — DM a peer
+
+The recipient's cc-server FSWatcher dispatches the channel push notification
+on ANY new `.msg` file landing in `inbox/<their-sid>/`. Direct write works
+just like MCP send — same dispatch path on the recipient side.
+
+```bash
+# resolve target short_id → full session_id
+TARGET_SID=$(sqlite3 ~/.claude/channels/cc/sessions.db \
+  "SELECT id FROM sessions WHERE substr(id,1,8)='abcd1234' AND ended_at_ms IS NULL LIMIT 1")
+
+# build .msg file via the helper (handles escaping + atomic write)
+bash ${CLAUDE_PLUGIN_ROOT}/bin/cc-quick send "$TARGET_SID" "your message here" "optional subject"
+```
+
+If the helper isn't on disk yet (older install), use this canonical format:
+```
+From: <my_short_id> @ <cwd_basename>
+From-Sid: <my_full_sid>
+Urgency: normal
+Timestamp: <ms_epoch>
+Subject: <subject if any>
+---
+<body>
+```
+Filename: `<timestamp_ms>-<my_full_sid>-<msg_id>.msg`. Atomic write
+(`<file>.tmp` then `mv`). Drop in `~/.claude/channels/cc/inbox/<target>/`.
+
+### announce — broadcast status to all peers
+
+```bash
+sqlite3 ~/.claude/channels/cc/sessions.db <<SQL
+INSERT INTO announcements (id, session_id, summary, detail, created_at_ms)
+VALUES ('$(uuidgen | tr -d - | head -c 16)', '$CLAUDE_CODE_SESSION_ID',
+        'refactoring auth.ts', NULL, $(date +%s%N | head -c 13));
+SQL
+```
+
+Or use the helper: `bash ${CLAUDE_PLUGIN_ROOT}/bin/cc-quick announce "summary text"`.
+
+### check — pull the awareness digest
+
+For just "what's new since last check," sqlite is fine:
+```bash
+sqlite3 ~/.claude/channels/cc/sessions.db \
+  "SELECT a.summary, a.detail, datetime(a.created_at_ms/1000,'unixepoch','localtime'),
+          substr(a.session_id,1,8)
+   FROM announcements a
+   JOIN sessions s ON s.id=a.session_id
+   WHERE s.ended_at_ms IS NULL
+     AND a.session_id != '$CLAUDE_CODE_SESSION_ID'
+     AND a.created_at_ms > (strftime('%s','now')*1000 - 30*60*1000)
+   ORDER BY a.created_at_ms DESC LIMIT 10"
+```
+
+For the rich `digest_delta` + `subscription_matches` shape with proper
+`last_checked_at_ms` advancement, prefer the MCP tool when it's reachable.
+
+## The MCP path (when registered)
+
+If `mcp__cc__cc` is in your tool list, prefer it for:
+- `subscribe` / `unsubscribe` (typed args, validation)
+- `check` (rich response shape with delta + subscription matches)
+- any send where you want the structured `delivered_to` confirmation
+
+```
+cc({ action: "sessions" })
+cc({ action: "send", to: "abcd1234", message: "30d vs 90d?", urgency: "question", subject: "tokens" })
+cc({ action: "announce", summary: "refactoring auth.ts" })
+cc({ action: "check", since_s: 3600 })
+cc({ action: "subscribe", files: "src/auth/**", urgency_min: "question" })
+```
+
+The MCP tool registers at session start. The session that just ran
+`/plugin install cc@claude-code-tips` won't have it until that terminal
+restarts (Claude Code doesn't re-poll `tools/list` mid-session). New
+sessions opened after the install pick it up immediately.
+
+**Don't wait on it.** If MCP isn't reachable, use the fast path above —
+same state, same dispatch, lower latency.
 
 ## Pick the action
 
-| Intent | Action |
-|---|---|
-| "who else is running?", "any other claude open?" | `sessions` |
-| "tell <peer> X", "ask <peer> Y", "ping merizo" | `send` |
-| "let peers know I'm refactoring auth", "broadcast: tests are red" | `announce` |
-| "what's happening on this machine right now?", explicit poll | `check` |
-| "alert me when anyone touches src/auth/**" | `subscribe` |
-| "stop watching for that, here's the id" | `unsubscribe` |
+| Intent | Action | Fast path? |
+|---|---|---|
+| "who else is running?" | `sessions` (read sqlite) | ✓ |
+| "tell <peer> X" | `send` (write .msg file) | ✓ |
+| "let peers know X" | `announce` (insert sqlite) | ✓ |
+| "what's new" | `check` (sqlite query) | ✓ for plain; MCP for rich delta |
+| "watch src/auth/**" | `subscribe` | MCP only (typed args) |
+| "stop watching id=X" | `unsubscribe` | MCP only |
 
 ## Targeting peers (`send`)
 
 The `to` field accepts:
-
-- **short id** (8 hex chars from `cc(action='sessions')`) — preferred when
-  multiple sessions share a cwd basename
+- **short id** (8 hex chars from roster) — preferred
 - **full session id** — UUID4
 - **cwd basename** — convenient but ambiguous across worktrees
 
-Use `urgency='question'` only when you actually need a reply; otherwise
-`'normal'` (default) is right. `'urgent'` is reserved for blocking
-coordination (e.g. "I'm about to push to the same branch you're rebasing").
-
-## Subscriptions (`subscribe` / `unsubscribe`)
-
-Declarative match rules surfaced as `subscription_matches` alongside
-`digest_delta` on every cc call. Provide at least one of:
-
-- `files`: glob like `"src/auth/**"` or `"**/test_*.py"`. `**` = any depth,
-  `*` = single segment, `?` = single char.
-- `peers`: `"any"`, an 8-hex short id, or a full session id. Restricts the
-  sub to that peer's activity.
-- `urgency_min`: `"low" | "normal" | "question" | "urgent"`. Only meaningful
-  for DM matches; ignored for file/announce events.
-
-Subscriptions are advisory — they don't filter what `digest_delta` shows.
-The model still sees everything; matches highlight what to prioritize.
+For urgency, use `'question'` only when you actually need a reply; default
+`'normal'`. `'urgent'` is for blocking coordination ("about to push to your
+branch").
 
 ## Awareness loop
 
-- **Channel push notifications** cover realtime DM arrival; you don't need
-  to call `check` on every turn just to stay current.
-- **File-overlap alerts** in the digest are advisory, not blocking. Send a
-  message before continuing edits on a flagged file — that's the protocol.
-- **Announcements** are fire-and-forget broadcasts; peers see them in their
-  next digest. No reply expected.
-- **`digest_delta` rides every cc call** (v3.3+). When the peer-visible
-  state has changed since this session's last cc call, the response from
-  `sessions` / `send` / `announce` includes a `digest_delta` block with
-  new announcements, edited files, peer joins, peer leaves. You don't
-  have to call `check` to discover this — it surfaces wherever you happen
-  to be calling cc. Once observed, the delta is consumed; the next call
-  shows only changes after that point.
+- **The recipient's cc-server FSWatcher pushes channel notifications** the
+  moment a `.msg` file lands. Senders don't need MCP for this to work.
+- **File-overlap alerts** in the digest are advisory. Send a message before
+  continuing edits on a flagged file.
+- **`digest_delta` rides every cc call** (v3.3+). When using the MCP path,
+  responses include a `digest_delta` block with new announcements + edits +
+  peer joins/leaves since this session's last cc call. The fast path's
+  sqlite query covers the same data without the delta-cursor advance.
 
-## Examples
+## Why two paths?
 
-```
-# list peers
-cc({ action: "sessions" })
-
-# DM a peer (asking a question)
-cc({
-  action: "send",
-  to: "abcd1234",
-  message: "30d vs 90d refresh on auth tokens?",
-  urgency: "question",
-  subject: "token ttl",
-})
-
-# broadcast status
-cc({
-  action: "announce",
-  summary: "refactoring auth.ts -- branch: feat/oauth",
-})
-
-# explicit digest poll
-cc({ action: "check", since_s: 3600 })
-```
-
-## What's NOT here
-
-- No topic verbs (`subscribe`, `unsubscribe`) — dropped in v3 pending
-  validation against real usage. Use `send` and `announce` for now.
-- No explicit `cleanup` — runs automatically on session shutdown.
+- The fast path **always works**, including in the install-trigger session.
+- The MCP path adds typed validation (zod), an exfil guard (rejects paths
+  resolving under cc state dir), and the `digest_delta` cursor.
+- Same sqlite + filesystem state behind both. Choose by latency need.


### PR DESCRIPTION
## Summary

The deeper fix for the install-trigger constraint. Treats the sqlite + filesystem direct-access path as first-class, not a fallback.

**The problem**: After \`/plugin install cc@claude-code-tips\` + \`/reload-plugins\`, the install-trigger session can't see the cc MCP tool until that terminal restarts. CC harness doesn't re-poll \`tools/list\` mid-session. Users felt that session was second-class.

**The fix**: Both paths become first-class.

- \`bin/cc-quick\` — bash + sqlite3 helper. \`roster\`, \`send\`, \`announce\`, \`check\`, \`mine\`. ~150 LOC, no deps beyond \`bash\`/\`sqlite3\`/\`uuidgen\`. Always works.
- \`SKILL.md\` reframes per-verb routing. sqlite is the FAST PATH for reads. Direct \`.msg\` write is the FAST PATH for send. MCP is for typed/validated subscribe/unsubscribe + rich \`digest_delta\` shape.

**Architectural insight**: The recipient's cc-server FSWatcher dispatches the channel push notification on ANY new \`.msg\` file in their inbox dir, regardless of who wrote it. Senders don't need MCP for the contract to hold. The previous SKILL.md was wrong about this.

## Verification

- [x] \`bun test tests/\` — 44 pass / 0 fail
- [x] \`cc-quick roster\` produces correct output
- [x] \`cc-quick send\` writes valid \`.msg\` (header + \`---\` + body, atomic via \`.tmp\` → \`mv\`)
- [x] Recipient FSWatcher would emit channel push on landing (path matches \`server.ts\` watcher's pattern)

## Test plan post-merge

In the install-trigger session (no MCP tool):
\`\`\`bash
bash ~/.claude/plugins/cache/claude-code-tips/cc/3.6.0/bin/cc-quick roster
bash ~/.claude/plugins/cache/claude-code-tips/cc/3.6.0/bin/cc-quick send <peer-short-id> "test"
\`\`\`

Recipient should see the DM in their next \`/cc check\` (or via channel push if their MCP server is alive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)